### PR TITLE
Docs and test workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ sudo: false
 install:
   - nvm install 0.12
   - nvm use 0.12
-  - npm install -g elm@0.16.0
+  - npm install -g elm@0.16.0 elm-test@0.16.0
   - elm package install -y
-  - npm install elm-test
 
 script:
   - bin/fetch-configlet

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please keep the following in mind:
 
 - Please open an issue before creating a PR that makes significant (breaking) changes to an existing exercise or makes changes across many exercises. It is best to discuss these changes before doing the work.
 
-- Follow the coding standards found in [The Elm Style Guide](http://elm-lang.org/docs/style-guide).
+- Follow the coding standards found in [The Elm Style Guide](http://elm-lang.org/docs/style-guide). Please consider running [elm-format](https://github.com/avh4/elm-format) before submitting a pull request.
 
 - Watch out for trailing spaces, extra blank lines, and spaces in blank lines.
 
@@ -34,7 +34,7 @@ Please keep the following in mind:
 - Please do not add a README or README.md file to the exercise directory. The READMEs are constructed using shared metadata, which lives in the
 [exercism/x-common](https://github.com/exercism/x-common) repository.
 
-- Each problem should have a test suite, an example solution, and a template file for the real implementation. The CI build expects files to be named using the following convention. The example solution should be named `ExerciseModuleName.example`. The template file should be named `ExerciseModuleName.elm`. Test file should be named `ExerciseModuleNameTest.elm`.
+- Each exercise should have a test suite, an example solution, a template file for the real implementation and an `elm-package.json` file with the `elm-test` and `elm-console` dependencies. The CI build expects files to be named using the following convention. The example solution should be named `ExerciseModuleName.example`. The template file should be named `ExerciseModuleName.elm`. Test file should be named `ExerciseModuleNameTest.elm`.
 
 - Test files should use the following format:
 
@@ -59,7 +59,7 @@ port runner =
 
  - All the tests for xElm exercises can be run from the top level of the repo with `bin/build.sh`. Please run this command before submitting your PR.
 
- - If you are submitting a new exercise, be sure to add it to the appropriate place in `config.json` and `elm-package.json` files. Also, please run `bin/fetch-configlet && bin/configlet` to ensure the exercise is configured correctly.
+ - If you are submitting a new exercise, be sure to add it to the appropriate place in the `config.json` and `elm-package.json` files. Also, please run `bin/fetch-configlet && bin/configlet` to ensure the exercise is configured correctly.
 
 ## License
 

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,0 +1,7 @@
+Elm's goal is to be the best of functional programming in the browser.
+
+One of the primary goals of Elm is to completely eliminate runtime exceptions before they reach production by combining an aggressively helpful compiler with solid architectural principles.
+
+Elm was designed by Evan Czaplicki as part of writing his thesis on [Concurrent FRP for Functional GUIs](http://elm-lang.org/papers/concurrent-frp.pdf).
+
+You can learn more about Elm at the [official website](http://elm-lang.org/)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,8 +1,9 @@
-Download and install a recent Elm Platform for your OS from [elm-lang.org/install](http://elm-lang.org/install).
+## Installing on any platform
 
-## MacOS
+The simplest way to install Elm is via Node.js/NPM.
+
+If you don't already have Node.js installed on your computer, you can download it from [the official site](https://nodejs.org/). Once you have Node.js up and running, follow these steps to install the Elm platform and elm-test.
 
 ```bash
 $ npm install --global elm elm-test
-$ elm-package install -y
 ```

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,0 +1,7 @@
+## Recommended Learning Resources
+
+Exercism provides exercises and feedback but can be difficult to jump into for those learning Elm for the first time. The best starting place is with the [official Elm docs](http://elm-lang.org/docs).
+
+## Interactive Examples
+
+[Try Elm](http://elm-lang.org/try) provides a number of interactive Elm examples you can edit live in your browser.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,15 +1,24 @@
-Run tests with soemthing like the following command:
+Elm exercises within your exercism project directory can be run by changing to the exercise directory, and running `elm-test NameOfTests.elm`.
+
 ```bash
-$ elm-test exercises/bob/BobTests.elm
+$ cd exercism/project/directory/elm/hello-world
+$ elm-test HelloWorldTests.elm
 ```
 
-## Making Your First Elm Module
+When you first run `elm-test` for an exercise it will prompt you to install the test library dependencies. If you type "y" and hit enter, the script should take care of the rest.
 
-To create a module that can be loaded with `import BobExample exposing (responseFor)`, put this code in `BobExample.elm`:
+## Hints and tips
 
-```elm
-module BobExample where
+### Coding the exercise
 
-responseFor : String -> String
-responseFor statement = undefined
-```
+The README.md for each exercise gives a general description but the Elm test program will be very specific. Open the test program and give it a quick look - if it seems like cheating, do it anyway. Look for helpful comments, test data, and just the names of the test functions. Try running the test command before you have written anything and see if the error messages give you an idea of where to start.
+
+Your first goal it to get something to compile, even though it fails tests. For this, you should "stub" functions. That means leave the body empty, except for whatever it must return. Write something like `myFunc param = 0` or whatever it takes just to get it to compile. Sometimes to figure out function types you will have to go back to the test program and read in more detail. Once you have figured out all the required function signatures, the test program will complain that `0` is the wrong answer. Now start filling in function bodies.
+
+### Fixing
+
+It will often be helpful to focus on the first failing test. Fix that one, repeat until no errors. Compile errors and warnings will produce lots of helpful output.
+
+### Cleaning up your code
+
+Consider running [`elm-format`](https://github.com/avh4/elm-format) on your code before submitting it.

--- a/exercises/bob/elm-package.json
+++ b/exercises/bob/elm-package.json
@@ -4,10 +4,7 @@
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
     "source-directories": [
-        ".",
-        "./exercises/hello-world",
-        "./exercises/leap",
-        "./exercises/bob"
+        "."
     ],
     "exposed-modules": [],
     "dependencies": {

--- a/exercises/hello-world/HelloWorld.elm
+++ b/exercises/hello-world/HelloWorld.elm
@@ -1,1 +1,25 @@
-module HelloWorld where
+{-
+This is a "stub" file.  It's a little start on your solution. It's not a
+complete solution though; you have to write some code.
+
+The module name is expected by the test program and must match the name of this
+file. It has to stay just the way it is.
+-}
+
+
+module HelloWorld (..) where
+
+-- It's good style to include a types at the top level of your modules.
+
+
+helloWorld : Maybe String -> String
+helloWorld name =
+  "replace with your code!"
+
+
+
+{-
+When you have a working solution, REMOVE ALL THE STOCK COMMENTS.
+They're here to help you get started but they only clutter a finished solution.
+If you leave them in, nitpickers will protest!
+-}

--- a/exercises/hello-world/HelloWorld.example
+++ b/exercises/hello-world/HelloWorld.example
@@ -1,7 +1,8 @@
-module HelloWorld where
+module HelloWorld (..) where
 
-helloworld : Maybe String -> String
-helloworld name =
+
+helloWorld : Maybe String -> String
+helloWorld name =
   case name of
     Just name ->
        "Hello, " ++ name ++ "!"

--- a/exercises/hello-world/HelloWorldTests.elm
+++ b/exercises/hello-world/HelloWorldTests.elm
@@ -1,17 +1,18 @@
-import String
-import Task
+module Main (..) where
 
+import Task
 import Console
 import ElmTest exposing (..)
-import HelloWorld exposing (..)
+import HelloWorld exposing (helloWorld)
 
 
 tests : Test
 tests =
-  suite "Hello, World!"
-    [ test "Hello with no name" (assertEqual "Hello, World!" (helloworld Nothing))
-    , test "Hello to a sample name" (assertEqual "Hello, Alice!" (helloworld (Just "Alice")))
-    , test "Hello to another sample name" (assertEqual "Hello, Bob!" (helloworld (Just "Bob")))
+  suite
+    "Hello, World!"
+    [ test "Hello with no name" (assertEqual "Hello, World!" (helloWorld Nothing))
+    , test "Hello to a sample name" (assertEqual "Hello, Alice!" (helloWorld (Just "Alice")))
+    , test "Hello to another sample name" (assertEqual "Hello, Bob!" (helloWorld (Just "Bob")))
     ]
 
 

--- a/exercises/hello-world/elm-package.json
+++ b/exercises/hello-world/elm-package.json
@@ -4,10 +4,7 @@
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
     "source-directories": [
-        ".",
-        "./exercises/hello-world",
-        "./exercises/leap",
-        "./exercises/bob"
+        "."
     ],
     "exposed-modules": [],
     "dependencies": {

--- a/exercises/leap/elm-package.json
+++ b/exercises/leap/elm-package.json
@@ -4,10 +4,7 @@
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
     "source-directories": [
-        ".",
-        "./exercises/hello-world",
-        "./exercises/leap",
-        "./exercises/bob"
+        "."
     ],
     "exposed-modules": [],
     "dependencies": {


### PR DESCRIPTION
As proposed in https://github.com/exercism/xelm/issues/23, I copied the `elm-package.json` file to each exercise directory and updated the docs to reflect this change.

I also adapted the TESTS.md from the exercism/xgo repo. I'm going to throw something in ABOUT/LEARNING/RESOURCES docs as well, but I wanted to get this up for your perusal @parkerl 