### PR TITLE
Detect failing example tests on Travis CI

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -7,6 +7,12 @@ do
   echo '-------------------------------------------------------'
   echo "Testing $exercise"
   elm-test $exercise_dir/*Tests.elm
+  TEST_RESULT=$?
   mv "$exercise_dir/$exercise.elm" "$exercise_dir/$exercise.example"
   mv "$exercise_dir/$exercise.impl" "$exercise_dir/$exercise.elm"
+
+  if [ $TEST_RESULT -ne 0 ]; then
+    echo "$exercise failed";
+    exit $TEST_RESULT;
+  fi
 done

--- a/elm-package.json
+++ b/elm-package.json
@@ -5,7 +5,7 @@
     "license": "BSD3",
     "source-directories": [
         ".",
-        "./exercises/hello_world",
+        "./exercises/hello-world",
         "./exercises/leap",
         "./exercises/bob"
     ],


### PR DESCRIPTION
It turns out the build.sh script doesn't actually error out if one of the tests fail. This change should fix that (along with making the hello-world test actually pass).