### PR TITLE
Cache elm-stuff directory in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ script:
   - bin/fetch-configlet
   - bin/configlet .
   - bin/build.sh
+
+cache:
+  directories:
+  - elm-stuff


### PR DESCRIPTION
I'm not sure how well elm caches incremental build stuff, but hopefully this will cut down on the quickly ballooning build time as we add exercises.