### PR TITLE
Collect exercise failures rather than exiting early.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,3 +1,6 @@
+declare -i TEST_RESULT=0
+FAILED_EXERCISES=''
+
 for example_file in exercises/**/*.example
 do
   exercise_dir=$(dirname $example_file)
@@ -7,12 +10,16 @@ do
   echo '-------------------------------------------------------'
   echo "Testing $exercise"
   elm-test $exercise_dir/*Tests.elm
-  TEST_RESULT=$?
+  if [ $? -ne 0 ]; then
+    TEST_RESULT=1
+    FAILED_EXERCISES+="$exercise\n"
+  fi
   mv "$exercise_dir/$exercise.elm" "$exercise_dir/$exercise.example"
   mv "$exercise_dir/$exercise.impl" "$exercise_dir/$exercise.elm"
-
-  if [ $TEST_RESULT -ne 0 ]; then
-    echo "$exercise failed";
-    exit $TEST_RESULT;
-  fi
 done
+
+if [ $TEST_RESULT -ne 0 ]; then
+  echo "The following exercises failed"
+  printf $FAILED_EXERCISES
+  exit $TEST_RESULT
+fi


### PR DESCRIPTION
I generally feel that the build script should accumulate all the errors and report them before exiting. This is nice when testing changes to many exercises. However, we may want to fail fast on CI given the length of the build...thoughts?