### PR TITLE
Make it easy to run `elm-format` locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Please keep the following in mind:
 
   - Make sure everything is good to go by running all tests with `bin/build.sh`.
 
+  - If you have [elm-format](https://github.com/avh4/elm-format) installed, you can easily check the project by running `WITH_FORMAT=true bin/build.sh`. If you get diffs on exercises other than the one you are working on, please submit a separate pull request.
+
 - Please do not commit any Elm configuration files or directories inside the exercise, such as `elm-stuff`. Please include only the standard `elm-package.json`.
 
 - Test files should use the following format:

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -10,10 +10,16 @@ do
   echo '-------------------------------------------------------'
   echo "Testing $exercise"
   elm-test $exercise_dir/*Tests.elm
+
   if [ $? -ne 0 ]; then
-    TEST_RESULT=1
-    FAILED_EXERCISES+="$exercise\n"
+      TEST_RESULT=1
+      FAILED_EXERCISES+="$exercise\n"
   fi
+
+  if [ $WITH_FORMAT ]; then
+    elm-format $exercise_dir/*.elm --yes
+  fi
+
   mv "$exercise_dir/$exercise.elm" "$exercise_dir/$exercise.example"
   mv "$exercise_dir/$exercise.impl" "$exercise_dir/$exercise.elm"
 done
@@ -23,3 +29,18 @@ if [ $TEST_RESULT -ne 0 ]; then
   printf $FAILED_EXERCISES
   exit $TEST_RESULT
 fi
+
+if [ $WITH_FORMAT ]; then
+  git diff --quiet --exit-code
+
+  if [ $? -ne 0 ]; then
+      echo "*******************************************************************"
+      echo "*******************************************************************"
+      echo "**Git diff found - perhaps some of your changes are not formatted?*"
+      echo "**       Please inspect the diffs before pushing.                **"
+      echo "*******************************************************************"
+      echo "*******************************************************************"
+      exit 1
+  fi
+fi
+


### PR DESCRIPTION
I thought this might make it easy for folks to run `elm-format` before submitting a PR. Thought @tgecho ?

- run WITH_FORMAT=true bin/build.sh