### PR TITLE
Standardize on module statements without `(..)`

### DIFF
--- a/exercises/accumulate/Accumulate.elm
+++ b/exercises/accumulate/Accumulate.elm
@@ -1,1 +1,1 @@
-module Accumulate (..) where
+module Accumulate where

--- a/exercises/accumulate/Accumulate.example
+++ b/exercises/accumulate/Accumulate.example
@@ -1,4 +1,4 @@
-module Accumulate (..) where
+module Accumulate where
 
 
 accumulate : (a -> b) -> List a -> List b

--- a/exercises/accumulate/AccumulateTests.elm
+++ b/exercises/accumulate/AccumulateTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/anagram/Anagram.elm
+++ b/exercises/anagram/Anagram.elm
@@ -1,1 +1,1 @@
-module Anagram (..) where
+module Anagram where

--- a/exercises/anagram/Anagram.example
+++ b/exercises/anagram/Anagram.example
@@ -1,4 +1,4 @@
-module Anagram (..) where
+module Anagram where
 
 import String exposing (toLower, toList)
 

--- a/exercises/anagram/AnagramTests.elm
+++ b/exercises/anagram/AnagramTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/bob/Bob.example
+++ b/exercises/bob/Bob.example
@@ -1,4 +1,4 @@
-module Bob (..) where
+module Bob where
 
 import String
 import Regex

--- a/exercises/bob/BobTests.elm
+++ b/exercises/bob/BobTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/difference-of-squares/DifferenceOfSquares.elm
+++ b/exercises/difference-of-squares/DifferenceOfSquares.elm
@@ -1,1 +1,1 @@
-module DifferenceOfSquares (..) where
+module DifferenceOfSquares where

--- a/exercises/difference-of-squares/DifferenceOfSquares.example
+++ b/exercises/difference-of-squares/DifferenceOfSquares.example
@@ -1,4 +1,4 @@
-module DifferenceOfSquares (..) where
+module DifferenceOfSquares where
 
 
 squareOfSum : Int -> Int

--- a/exercises/difference-of-squares/DifferenceOfSquaresTests.elm
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/grade-school/GradeSchool.elm
+++ b/exercises/grade-school/GradeSchool.elm
@@ -1,2 +1,2 @@
-module GradeSchool (..) where
+module GradeSchool where
 

--- a/exercises/grade-school/GradeSchool.example
+++ b/exercises/grade-school/GradeSchool.example
@@ -1,4 +1,4 @@
-module GradeSchool (..) where
+module GradeSchool where
 
 import Dict exposing (..)
 

--- a/exercises/grade-school/GradeSchoolTests.elm
+++ b/exercises/grade-school/GradeSchoolTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/hamming/Hamming.elm
+++ b/exercises/hamming/Hamming.elm
@@ -1,1 +1,1 @@
-module Hamming (..) where
+module Hamming where

--- a/exercises/hamming/Hamming.example
+++ b/exercises/hamming/Hamming.example
@@ -1,4 +1,4 @@
-module Hamming (..) where
+module Hamming where
 
 import String exposing (length, toList)
 

--- a/exercises/hamming/HammingTests.elm
+++ b/exercises/hamming/HammingTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/hello-world/HelloWorld.elm
+++ b/exercises/hello-world/HelloWorld.elm
@@ -7,7 +7,7 @@ file. It has to stay just the way it is.
 -}
 
 
-module HelloWorld (..) where
+module HelloWorld where
 
 -- It's good style to include a types at the top level of your modules.
 

--- a/exercises/hello-world/HelloWorld.example
+++ b/exercises/hello-world/HelloWorld.example
@@ -1,4 +1,4 @@
-module HelloWorld (..) where
+module HelloWorld where
 
 
 helloWorld : Maybe String -> String

--- a/exercises/hello-world/HelloWorldTests.elm
+++ b/exercises/hello-world/HelloWorldTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/leap/Leap.elm
+++ b/exercises/leap/Leap.elm
@@ -1,1 +1,1 @@
-module Leap (..) where
+module Leap where

--- a/exercises/leap/Leap.example
+++ b/exercises/leap/Leap.example
@@ -1,4 +1,4 @@
-module Leap (..) where
+module Leap where
 
 
 isLeapYear : Int -> Bool

--- a/exercises/leap/LeapTests.elm
+++ b/exercises/leap/LeapTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/nucleotide-count/NucleotideCount.elm
+++ b/exercises/nucleotide-count/NucleotideCount.elm
@@ -1,1 +1,1 @@
-module NucleotideCount (..) where
+module NucleotideCount where

--- a/exercises/nucleotide-count/NucleotideCount.example
+++ b/exercises/nucleotide-count/NucleotideCount.example
@@ -1,4 +1,4 @@
-module NucleotideCount (..) where
+module NucleotideCount where
 
 import String
 import List

--- a/exercises/nucleotide-count/NucleotideCountTests.elm
+++ b/exercises/nucleotide-count/NucleotideCountTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/pangram/Pangram.example
+++ b/exercises/pangram/Pangram.example
@@ -1,4 +1,4 @@
-module Pangram (..) where
+module Pangram where
 
 import String exposing (toLower, contains, fromChar)
 

--- a/exercises/pangram/PangramTests.elm
+++ b/exercises/pangram/PangramTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/phone-number/PhoneNumber.elm
+++ b/exercises/phone-number/PhoneNumber.elm
@@ -1,1 +1,1 @@
-module PhoneNumber (..) where
+module PhoneNumber where

--- a/exercises/phone-number/PhoneNumber.example
+++ b/exercises/phone-number/PhoneNumber.example
@@ -1,4 +1,4 @@
-module PhoneNumber (..) where
+module PhoneNumber where
 
 import String
 

--- a/exercises/phone-number/PhoneNumberTests.elm
+++ b/exercises/phone-number/PhoneNumberTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/raindrops/Raindrops.elm
+++ b/exercises/raindrops/Raindrops.elm
@@ -1,1 +1,1 @@
-module Raindrops (..) where
+module Raindrops where

--- a/exercises/raindrops/Raindrops.example
+++ b/exercises/raindrops/Raindrops.example
@@ -1,4 +1,4 @@
-module Raindrops (..) where
+module Raindrops where
 
 import String
 

--- a/exercises/raindrops/RaindropsTests.elm
+++ b/exercises/raindrops/RaindropsTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/rna-transcription/RNATranscription.elm
+++ b/exercises/rna-transcription/RNATranscription.elm
@@ -1,1 +1,1 @@
-module RNATranscription (..) where
+module RNATranscription where

--- a/exercises/rna-transcription/RNATranscriptionTests.elm
+++ b/exercises/rna-transcription/RNATranscriptionTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/run-length-encoding/RunLengthEncoding.elm
+++ b/exercises/run-length-encoding/RunLengthEncoding.elm
@@ -1,1 +1,1 @@
-module RunLengthEncoding (..) where
+module RunLengthEncoding where

--- a/exercises/run-length-encoding/RunLengthEncodingTests.elm
+++ b/exercises/run-length-encoding/RunLengthEncodingTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/space-age/SpaceAge.elm
+++ b/exercises/space-age/SpaceAge.elm
@@ -1,4 +1,4 @@
-module SpaceAge (..) where
+module SpaceAge where
 
 type Planet
   = Mercury

--- a/exercises/space-age/SpaceAge.example
+++ b/exercises/space-age/SpaceAge.example
@@ -1,4 +1,4 @@
-module SpaceAge (..) where
+module SpaceAge where
 
 
 type Planet

--- a/exercises/space-age/SpaceAgeTests.elm
+++ b/exercises/space-age/SpaceAgeTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/strain/Strain.elm
+++ b/exercises/strain/Strain.elm
@@ -1,1 +1,1 @@
-module Strain (..) where
+module Strain where

--- a/exercises/strain/Strain.example
+++ b/exercises/strain/Strain.example
@@ -1,4 +1,4 @@
-module Strain (..) where
+module Strain where
 
 import List
 

--- a/exercises/strain/StrainTests.elm
+++ b/exercises/strain/StrainTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/sublist/Sublist.elm
+++ b/exercises/sublist/Sublist.elm
@@ -1,1 +1,1 @@
-module Sublist (..) where
+module Sublist where

--- a/exercises/sublist/Sublist.example
+++ b/exercises/sublist/Sublist.example
@@ -1,4 +1,4 @@
-module Sublist (..) where
+module Sublist where
 
 import List exposing (..)
 import String

--- a/exercises/sublist/SublistTests.elm
+++ b/exercises/sublist/SublistTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/sum-of-multiples/SumOfMultiples.elm
+++ b/exercises/sum-of-multiples/SumOfMultiples.elm
@@ -1,1 +1,1 @@
-module SumOfMultiples (..) where
+module SumOfMultiples where

--- a/exercises/sum-of-multiples/SumOfMultiples.example
+++ b/exercises/sum-of-multiples/SumOfMultiples.example
@@ -1,4 +1,4 @@
-module SumOfMultiples (..) where
+module SumOfMultiples where
 
 
 sumOfMultiples : List Int -> Int -> Int

--- a/exercises/sum-of-multiples/SumOfMultiplesTests.elm
+++ b/exercises/sum-of-multiples/SumOfMultiplesTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/triangle/Triangle.elm
+++ b/exercises/triangle/Triangle.elm
@@ -1,1 +1,1 @@
-module Triangle (..) where
+module Triangle where

--- a/exercises/triangle/Triangle.example
+++ b/exercises/triangle/Triangle.example
@@ -1,4 +1,4 @@
-module Triangle (..) where
+module Triangle where
 
 import Set
 

--- a/exercises/triangle/TriangleTests.elm
+++ b/exercises/triangle/TriangleTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console

--- a/exercises/word-count/WordCount.elm
+++ b/exercises/word-count/WordCount.elm
@@ -1,1 +1,1 @@
-module WordCount (..) where
+module WordCount where

--- a/exercises/word-count/WordCount.example
+++ b/exercises/word-count/WordCount.example
@@ -1,4 +1,4 @@
-module WordCount (..) where
+module WordCount where
 
 import String
 import Dict exposing (Dict)

--- a/exercises/word-count/WordCountTests.elm
+++ b/exercises/word-count/WordCountTests.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main where
 
 import Task
 import Console


### PR DESCRIPTION
This one is totally pedantic. I recently confirmed that the `(..)` is totally redundant in Elm. Both of these versions will export everything in the module:

```elm
module Foo (..) where
module Foo where
```

We are a bit inconsistent in our usage, though most of the exercises I added use the `(..)`. Since it's apparently superfluous, I think we should simply remove it.