### PR TITLE
Switch nucleotide-counts from `List (Char Int)` to `Dict Char Int`

### DIFF
--- a/exercises/nucleotide-count/NucleotideCount.elm
+++ b/exercises/nucleotide-count/NucleotideCount.elm
@@ -1,1 +1,5 @@
 module NucleotideCount (..) where
+
+
+version =
+  2

--- a/exercises/nucleotide-count/NucleotideCount.example
+++ b/exercises/nucleotide-count/NucleotideCount.example
@@ -8,9 +8,13 @@ version =
   2
 
 
+empty =
+  Dict.fromList [ ( 'A', 0 ), ( 'C', 0 ), ( 'G', 0 ), ( 'T', 0 ) ]
+
+
 nucleotideCounts : String -> Dict.Dict Char Int
 nucleotideCounts dna =
-  String.foldl count Dict.empty dna
+  String.foldl count empty dna
 
 
 count : comparable -> Dict.Dict comparable Int -> Dict.Dict comparable Int

--- a/exercises/nucleotide-count/NucleotideCount.example
+++ b/exercises/nucleotide-count/NucleotideCount.example
@@ -1,18 +1,23 @@
-module NucleotideCount (..) where
+module NucleotideCount (nucleotideCounts, version) where
 
+import Dict
 import String
-import List
 
 
-nucleotideCounts : String -> List ( Char, Int )
-nucleotideCounts sequence =
-  [ (getCount 'A' sequence)
-  , (getCount 'T' sequence)
-  , (getCount 'C' sequence)
-  , (getCount 'G' sequence)
-  ]
+version =
+  2
 
 
-getCount : Char -> String -> ( Char, Int )
-getCount base sequence =
-  ( base, (List.length (String.split (String.fromChar base) sequence)) - 1 )
+nucleotideCounts : String -> Dict.Dict Char Int
+nucleotideCounts dna =
+  String.foldl count Dict.empty dna
+
+
+count : comparable -> Dict.Dict comparable Int -> Dict.Dict comparable Int
+count item counts =
+  Dict.update item incrMaybe counts
+
+
+incrMaybe : Maybe Int -> Maybe Int
+incrMaybe maybe =
+  (Maybe.withDefault 0 maybe) + 1 |> Just

--- a/exercises/nucleotide-count/NucleotideCountTests.elm
+++ b/exercises/nucleotide-count/NucleotideCountTests.elm
@@ -3,7 +3,8 @@ module Main (..) where
 import Task
 import Console
 import ElmTest exposing (..)
-import NucleotideCount exposing (nucleotideCounts)
+import NucleotideCount exposing (nucleotideCounts, version)
+import Dict
 
 
 tests : Test
@@ -11,22 +12,25 @@ tests =
   suite
     "NucleotideCount"
     [ test
+        "the solution is for the current version"
+        (assertEqual 2 version)
+    , test
         "empty dna strand has no nucleotides"
         (assertEqual
-          [ ( 'A', 0 ), ( 'T', 0 ), ( 'C', 0 ), ( 'G', 0 ) ]
-          (nucleotideCounts "")
+          []
+          (Dict.toList (nucleotideCounts ""))
         )
     , test
         "repetitive-sequence-has-only-guanosine"
         (assertEqual
-          [ ( 'A', 0 ), ( 'T', 0 ), ( 'C', 0 ), ( 'G', 8 ) ]
-          (nucleotideCounts "GGGGGGGG")
+          ([ ( 'G', 8 ) ])
+          (Dict.toList (nucleotideCounts "GGGGGGGG"))
         )
     , test
         "counts all nucleotides"
         (assertEqual
-          [ ( 'A', 20 ), ( 'T', 21 ), ( 'C', 12 ), ( 'G', 17 ) ]
-          (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")
+          [ ( 'A', 20 ), ( 'C', 12 ), ( 'G', 17 ), ( 'T', 21 ) ]
+          (Dict.toList (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"))
         )
     ]
 

--- a/exercises/nucleotide-count/NucleotideCountTests.elm
+++ b/exercises/nucleotide-count/NucleotideCountTests.elm
@@ -17,13 +17,13 @@ tests =
     , test
         "empty dna strand has no nucleotides"
         (assertEqual
-          []
+          [ ( 'A', 0 ), ( 'C', 0 ), ( 'G', 0 ), ( 'T', 0 ) ]
           (Dict.toList (nucleotideCounts ""))
         )
     , test
         "repetitive-sequence-has-only-guanosine"
         (assertEqual
-          ([ ( 'G', 8 ) ])
+          ([ ( 'A', 0 ), ( 'C', 0 ), ( 'G', 8 ), ( 'T', 0 ) ])
           (Dict.toList (nucleotideCounts "GGGGGGGG"))
         )
     , test


### PR DESCRIPTION
I didn't look at this exercise hard enough when I picked it from the other repo. When I actually sat down to do my own from scratch solution, I realized that the `List (Char Int)` output it was looking for felt a bit arbitrary, with the counts needing to be in a specific (non alphabetical) order.

I revised it to look for a Dict instead, which seems like a more natural container for this sort of problem. Note that I did include a version, as recommended in https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#exercise-versioning

In the process I did learn something unfortunate about `Dict`: ["Dictionary equality with (==) is unreliable and should not be used."](http://package.elm-lang.org/packages/elm-lang/core/3.0.0/Dict)