### PR TITLE
Convert nucleotide-counts to use a record rather than a `List (Char, Int)`

### DIFF
--- a/exercises/nucleotide-count/NucleotideCount.example
+++ b/exercises/nucleotide-count/NucleotideCount.example
@@ -1,18 +1,16 @@
 module NucleotideCount (..) where
 
 import String
-import List
 
 
-nucleotideCounts : String -> List ( Char, Int )
+nucleotideCounts : String -> { a : Int, t : Int, c : Int, g : Int }
 nucleotideCounts sequence =
-  [ (getCount 'A' sequence)
-  , (getCount 'T' sequence)
-  , (getCount 'C' sequence)
-  , (getCount 'G' sequence)
-  ]
-
-
-getCount : Char -> String -> ( Char, Int )
-getCount base sequence =
-  ( base, (List.length (String.split (String.fromChar base) sequence)) - 1 )
+  let
+    getCount n =
+      String.filter (\c -> c == n) sequence |> String.length
+  in
+    { a = getCount 'A'
+    , t = getCount 'T'
+    , c = getCount 'C'
+    , g = getCount 'G'
+    }

--- a/exercises/nucleotide-count/NucleotideCountTests.elm
+++ b/exercises/nucleotide-count/NucleotideCountTests.elm
@@ -13,19 +13,19 @@ tests =
     [ test
         "empty dna strand has no nucleotides"
         (assertEqual
-          [ ( 'A', 0 ), ( 'T', 0 ), ( 'C', 0 ), ( 'G', 0 ) ]
+          { a = 0, t = 0, c = 0, g = 0 }
           (nucleotideCounts "")
         )
     , test
         "repetitive-sequence-has-only-guanosine"
         (assertEqual
-          [ ( 'A', 0 ), ( 'T', 0 ), ( 'C', 0 ), ( 'G', 8 ) ]
+          { a = 0, t = 0, c = 0, g = 8 }
           (nucleotideCounts "GGGGGGGG")
         )
     , test
         "counts all nucleotides"
         (assertEqual
-          [ ( 'A', 20 ), ( 'T', 21 ), ( 'C', 12 ), ( 'G', 17 ) ]
+          { a = 20, t = 21, c = 12, g = 17 }
           (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")
         )
     ]


### PR DESCRIPTION
As a spin off from https://github.com/exercism/xelm/pull/46, here's a different version using records. It's maybe a bit more prescriptive, but I actually kinda like it. Since there are actually only four possible keys, a fixed (and typed) record actually feels pretty reasonable. It also introduces records (which we haven't done) in a fairly simple way.