### PR TITLE
Sort returned nucleotide-count results to make the test order independent

### DIFF
--- a/exercises/nucleotide-count/NucleotideCountTests.elm
+++ b/exercises/nucleotide-count/NucleotideCountTests.elm
@@ -6,6 +6,10 @@ import ElmTest exposing (..)
 import NucleotideCount exposing (nucleotideCounts)
 
 
+sorted =
+  List.sortBy fst
+
+
 tests : Test
 tests =
   suite
@@ -13,20 +17,20 @@ tests =
     [ test
         "empty dna strand has no nucleotides"
         (assertEqual
-          [ ( 'A', 0 ), ( 'T', 0 ), ( 'C', 0 ), ( 'G', 0 ) ]
-          (nucleotideCounts "")
+          [ ( 'A', 0 ), ( 'C', 0 ), ( 'G', 0 ), ( 'T', 0 ) ]
+          (sorted (nucleotideCounts ""))
         )
     , test
         "repetitive-sequence-has-only-guanosine"
         (assertEqual
-          [ ( 'A', 0 ), ( 'T', 0 ), ( 'C', 0 ), ( 'G', 8 ) ]
-          (nucleotideCounts "GGGGGGGG")
+          [ ( 'A', 0 ), ( 'C', 0 ), ( 'G', 8 ), ( 'T', 0 ) ]
+          (sorted (nucleotideCounts "GGGGGGGG"))
         )
     , test
         "counts all nucleotides"
         (assertEqual
-          [ ( 'A', 20 ), ( 'T', 21 ), ( 'C', 12 ), ( 'G', 17 ) ]
-          (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")
+          [ ( 'A', 20 ), ( 'C', 12 ), ( 'G', 17 ), ( 'T', 21 ) ]
+          (sorted (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"))
         )
     ]
 


### PR DESCRIPTION
As a spin off from https://github.com/exercism/xelm/pull/46, here's a simple version where we sort the output to make it more forgiving.