### PR TITLE
Add additional test cases (including a property based test!) to run-length-encoding

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -28,6 +28,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "NoRedInk/elm-check": "3.0.0 <= v < 4.0.0",
         "deadfoxygrandpa/elm-test": "3.0.1 <= v < 4.0.0",
         "elm-lang/core": "2.0.0 <= v < 4.0.0",
         "laszlopandy/elm-console": "1.1.0 <= v < 2.0.0"

--- a/exercises/run-length-encoding/RunLengthEncoding.example
+++ b/exercises/run-length-encoding/RunLengthEncoding.example
@@ -1,4 +1,4 @@
-module RunLengthEncoding (encode, decode) where
+module RunLengthEncoding (version, encode, decode) where
 
 import String exposing (fromChar)
 import List exposing (head, tail)
@@ -10,6 +10,10 @@ import Regex
 To the unaware: this was written by a very green elmer, so don't consider
 it an idiomatic exemplar to emulate.
 -}
+
+
+version =
+  2
 
 
 encode : String -> String

--- a/exercises/run-length-encoding/RunLengthEncodingPropertyChecks.elm
+++ b/exercises/run-length-encoding/RunLengthEncodingPropertyChecks.elm
@@ -1,0 +1,64 @@
+module RunLengthEncodingPropertyChecks (propertyTests) where
+
+import ElmTest
+import Check exposing (suite, claim, that, is, for, quickCheck)
+import Check.Producer as P
+import Check.Test
+import RunLengthEncoding exposing (decode, encode)
+import String as S
+import Char
+
+
+{-
+Welcome! This is a property based test which will generate a bunch of random
+test cases in an attempt to find edge cases in your solution. If all goes well,
+any code that passes the regular tests should be fine here as well. If it goes
+less well, this should hopefully narrow the failure down to a useful test case.
+
+Good luck!
+-}
+
+
+claims : Check.Claim
+claims =
+  suite
+    "List Reverse"
+    [ claim
+        "Encoding and decoding yields the original string"
+        `that` (\input -> decode (encode (S.concat input)))
+        `is` S.concat
+        `for` inputProducer
+    ]
+
+
+inputProducer : P.Producer (List String)
+inputProducer =
+  P.tuple ( P.rangeInt 0 1001, upperCaseLetter )
+    |> P.convert
+        (\( n, c ) -> S.repeat n (S.fromChar c))
+        (\s ->
+          ( S.length s
+          , S.toList s |> List.head |> crashIfNothing
+          )
+        )
+    |> P.list
+
+
+upperCaseLetter : P.Producer Char
+upperCaseLetter =
+  P.filter Char.isUpper P.upperCaseChar
+
+
+crashIfNothing : Maybe a -> a
+crashIfNothing a =
+  case a of
+    Just a ->
+      a
+
+    Nothing ->
+      Debug.crash "Nothing!"
+
+
+propertyTests : ElmTest.Test
+propertyTests =
+  Check.Test.evidenceToTest (quickCheck claims)

--- a/exercises/run-length-encoding/RunLengthEncodingTests.elm
+++ b/exercises/run-length-encoding/RunLengthEncodingTests.elm
@@ -3,7 +3,8 @@ module Main (..) where
 import Task
 import Console
 import ElmTest exposing (..)
-import RunLengthEncoding exposing (decode, encode)
+import RunLengthEncoding exposing (version, decode, encode)
+import RunLengthEncodingPropertyChecks exposing (propertyTests)
 
 
 tests : Test
@@ -11,6 +12,9 @@ tests =
   suite
     "RunLengthEncoding"
     [ test
+        "the solution is for the correct version of the test"
+        (assertEqual 2 version)
+    , test
         "encode simple"
         (assertEqual "2A3B4C" (encode "AABBBCCCC"))
     , test
@@ -29,10 +33,16 @@ tests =
           (decode "12WB12W3B24WB")
         )
     , test
-        "decode(encode(...)) combination"
+        "(decode (encode (...)) combination"
         (assertEqual
           "zzz ZZ  zZ"
           (decode (encode "zzz ZZ  zZ"))
+        )
+    , test
+        "decode with a x10 value"
+        (assertEqual
+          "WWWWWWWWWW"
+          (decode "10W")
         )
     , test
         "encode unicode"
@@ -40,6 +50,7 @@ tests =
     , test
         "decode unicode"
         (assertEqual "⏰⚽⚽⚽⭐⭐⏰" (decode "⏰3⚽2⭐⏰"))
+    , propertyTests
     ]
 
 

--- a/exercises/run-length-encoding/elm-package.json
+++ b/exercises/run-length-encoding/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "NoRedInk/elm-check": "3.0.0 <= v < 4.0.0",
         "deadfoxygrandpa/elm-test": "3.0.1 <= v < 4.0.0",
         "elm-lang/core": "2.0.0 <= v < 4.0.0",
         "laszlopandy/elm-console": "1.1.0 <= v < 2.0.0"


### PR DESCRIPTION
A solution was submitted that seemed a bit off to me. After I whipped up a failing test case (which is added in this PR), I realized that this problem is a perfect candidate for property based testing.

I've never really written a property test beyond the hello world level before now, so I hope it doesn't look too crazy. It also seems to expose the same edge case failure that the original test suite missed. I did restrict the generated cases to sequences of upper case letters.

As for the actual execution, it does involve adding another dependency (elm-check). I wasn't sure if I wanted to make it an optional add-on, but for now it's imported as part of the regular tests. I incremented the version, though it should only be a breaking change for imperfect implementations! :)