### PR TITLE
refactor nucleotide-count

### DIFF
--- a/exercises/nucleotide-count/NucleotideCount.elm
+++ b/exercises/nucleotide-count/NucleotideCount.elm
@@ -1,5 +1,6 @@
 module NucleotideCount (..) where
 
 
+version : Int
 version =
   2

--- a/exercises/nucleotide-count/NucleotideCount.example
+++ b/exercises/nucleotide-count/NucleotideCount.example
@@ -3,18 +3,47 @@ module NucleotideCount (..) where
 import String
 
 
+version : Int
 version =
   2
 
 
-nucleotideCounts : String -> { a : Int, t : Int, c : Int, g : Int }
+type alias NucleotideCounts =
+  { a : Int
+  , t : Int
+  , c : Int
+  , g : Int
+  }
+
+
+init : NucleotideCounts
+init =
+  { a = 0
+  , t = 0
+  , c = 0
+  , g = 0
+  }
+
+
+update : Char -> NucleotideCounts -> NucleotideCounts
+update char counts =
+  case char of
+    'A' ->
+      { counts | a = counts.a + 1 }
+
+    'T' ->
+      { counts | t = counts.t + 1 }
+
+    'C' ->
+      { counts | c = counts.c + 1 }
+
+    'G' ->
+      { counts | g = counts.g + 1 }
+
+    _ ->
+      counts
+
+
+nucleotideCounts : String -> NucleotideCounts
 nucleotideCounts sequence =
-  let
-    getCount n =
-      String.filter (\c -> c == n) sequence |> String.length
-  in
-    { a = getCount 'A'
-    , t = getCount 'T'
-    , c = getCount 'C'
-    , g = getCount 'G'
-    }
+  String.foldl update init sequence


### PR DESCRIPTION
Hi!

I refactored nucleotide-count to accomplish the following goals:
- Reduce number of string iterations to 1
- Demonstrate fold(l|r|p)/update/init pattern which is common in Elm
- Demonstrate pattern-matching on literals
- Add a type alias for counts record

I know this is a significant change from the previous example but let me know what you think!