### PR TITLE
use backward application operator

### DIFF
--- a/exercises/robot-simulator/RobotSimulator.example
+++ b/exercises/robot-simulator/RobotSimulator.example
@@ -95,4 +95,4 @@ simulate directions robot =
     directions
       |> String.toList
       |> List.map action
-      |> List.foldl (\a r -> a r) robot
+      |> List.foldl (<|) robot


### PR DESCRIPTION
This is a small change to replace `(\a r -> a r)` with the equivalent `(<|)`. This use of `(<|)` comes up occasionally in package sources and seeing it used in this way really helped me to understand it.

Thanks!