### PR TITLE
refactor sublist

### DIFF
--- a/exercises/sublist/Sublist.elm
+++ b/exercises/sublist/Sublist.elm
@@ -1,1 +1,8 @@
 module Sublist (..) where
+
+
+type ListComparison
+  = Equal
+  | Superlist
+  | Sublist
+  | Unequal

--- a/exercises/sublist/Sublist.elm
+++ b/exercises/sublist/Sublist.elm
@@ -1,8 +1,1 @@
 module Sublist (..) where
-
-
-type ListComparison
-  = Equal
-  | Superlist
-  | Sublist
-  | Unequal

--- a/exercises/sublist/Sublist.example
+++ b/exercises/sublist/Sublist.example
@@ -1,6 +1,11 @@
 module Sublist (..) where
 
 
+version : Int
+version =
+  2
+
+
 type ListComparison
   = Equal
   | Superlist

--- a/exercises/sublist/Sublist.example
+++ b/exercises/sublist/Sublist.example
@@ -1,31 +1,30 @@
 module Sublist (..) where
 
-import List exposing (..)
-import String
+
+type ListComparison
+  = Equal
+  | Superlist
+  | Sublist
+  | Unequal
 
 
-sublist : List a -> List a -> String
+sublist : List a -> List a -> ListComparison
 sublist alist blist =
   if alist == blist then
-    "Equal"
+    Equal
   else if inList alist blist then
-    "Superlist"
+    Superlist
   else if inList blist alist then
-    "Sublist"
+    Sublist
   else
-    "Unequal"
+    Unequal
 
 
 inList : List a -> List a -> Bool
 inList alist blist =
   let
     getLastInList sublist =
-      case (List.tail sublist) of
-        Just list ->
-          list
-
-        Nothing ->
-          []
+      Maybe.withDefault [] (List.tail sublist)
   in
     if (List.length alist) < (List.length blist) then
       False

--- a/exercises/sublist/SublistTests.elm
+++ b/exercises/sublist/SublistTests.elm
@@ -3,7 +3,7 @@ module Main (..) where
 import Task
 import Console
 import ElmTest exposing (..)
-import Sublist exposing (sublist, ListComparison(..))
+import Sublist exposing (version, sublist, ListComparison(..))
 
 
 tests : Test
@@ -11,6 +11,9 @@ tests =
   suite
     "Sublist"
     [ test
+        "the solution is for the correct version of the test"
+        (assertEqual 2 version)
+    , test
         "empty equals empty"
         (assertEqual Equal (sublist [] []))
     , test

--- a/exercises/sublist/SublistTests.elm
+++ b/exercises/sublist/SublistTests.elm
@@ -3,7 +3,7 @@ module Main (..) where
 import Task
 import Console
 import ElmTest exposing (..)
-import Sublist exposing (sublist)
+import Sublist exposing (sublist, ListComparison(..))
 
 
 tests : Test
@@ -12,58 +12,58 @@ tests =
     "Sublist"
     [ test
         "empty equals empty"
-        (assertEqual "Equal" (sublist [] []))
+        (assertEqual Equal (sublist [] []))
     , test
         "empty is a sublist of anything"
-        (assertEqual "Sublist" (sublist [] [ 1, 2 ]))
+        (assertEqual Sublist (sublist [] [ 1, 2 ]))
     , test
         "anything is a superlist of empty"
-        (assertEqual "Superlist" (sublist [ 1, 2 ] []))
+        (assertEqual Superlist (sublist [ 1, 2 ] []))
     , test
         "1 is not 2"
-        (assertEqual "Unequal" (sublist [ 1 ] [ 2 ]))
+        (assertEqual Unequal (sublist [ 1 ] [ 2 ]))
     , test
         "compare larger equal lists"
-        (assertEqual "Equal" (sublist [ 1, 1, 1 ] [ 1, 1, 1 ]))
+        (assertEqual Equal (sublist [ 1, 1, 1 ] [ 1, 1, 1 ]))
     , test
         "sublist at start"
-        (assertEqual "Sublist" (sublist [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ]))
+        (assertEqual Sublist (sublist [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ]))
     , test
         "sublist in the middle"
-        (assertEqual "Sublist" (sublist [ 4, 3, 2 ] [ 5, 4, 3, 2, 1 ]))
+        (assertEqual Sublist (sublist [ 4, 3, 2 ] [ 5, 4, 3, 2, 1 ]))
     , test
         "sublist at end"
-        (assertEqual "Sublist" (sublist [ 3, 4, 5 ] [ 1, 2, 3, 4, 5 ]))
+        (assertEqual Sublist (sublist [ 3, 4, 5 ] [ 1, 2, 3, 4, 5 ]))
     , test
         "partially matching sublist at start"
-        (assertEqual "Sublist" (sublist [ 1, 1, 2 ] [ 1, 1, 1, 2 ]))
+        (assertEqual Sublist (sublist [ 1, 1, 2 ] [ 1, 1, 1, 2 ]))
     , test
         "sublist early in huge list"
-        (assertEqual "Sublist" (sublist [ 3, 4, 5 ] [1..100000]))
+        (assertEqual Sublist (sublist [ 3, 4, 5 ] [1..100000]))
     , test
         "huge sublist not in list"
-        (assertEqual "Unequal" (sublist [10..100001] [1..100000]))
+        (assertEqual Unequal (sublist [10..100001] [1..100000]))
     , test
         "superlist at start"
-        (assertEqual "Superlist" (sublist [ 1, 2, 3, 4, 5 ] [ 1, 2, 3 ]))
+        (assertEqual Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 1, 2, 3 ]))
     , test
         "superlist in middle"
-        (assertEqual "Superlist" (sublist [ 5, 4, 3, 2, 1 ] [ 4, 3, 2 ]))
+        (assertEqual Superlist (sublist [ 5, 4, 3, 2, 1 ] [ 4, 3, 2 ]))
     , test
         "superlist at end"
-        (assertEqual "Superlist" (sublist [ 1, 2, 3, 4, 5 ] [ 3, 4, 5 ]))
+        (assertEqual Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 3, 4, 5 ]))
     , test
         "partially matching superlist at start"
-        (assertEqual "Superlist" (sublist [ 1, 1, 1, 2 ] [ 1, 1, 2 ]))
+        (assertEqual Superlist (sublist [ 1, 1, 1, 2 ] [ 1, 1, 2 ]))
     , test
         "superlist early in huge list"
-        (assertEqual "Superlist" (sublist [1..100000] [ 3, 4, 5 ]))
+        (assertEqual Superlist (sublist [1..100000] [ 3, 4, 5 ]))
     , test
         "recurring values sublist"
-        (assertEqual "Sublist" (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 1, 2, 3, 2, 1 ]))
+        (assertEqual Sublist (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 1, 2, 3, 2, 1 ]))
     , test
         "recurring values unequal"
-        (assertEqual "Unequal" (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 3, 2, 3, 2, 1 ]))
+        (assertEqual Unequal (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 3, 2, 3, 2, 1 ]))
     ]
 
 


### PR DESCRIPTION
Hi!

This refactor has one larger change and one minor one:
- Uses a union type to represent comparison possibilities between lists. Union types should always be favored over Strings or Ints for expressing finite option sets as it allows the compiler to enforce their usage/spelling/etc.
- `getLastInList` is a textbook use case for `Maybe.withDefault`

Let me know what you think!