### PR TITLE
Add shebang to `bin/build.sh`

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 declare -i TEST_RESULT=0
 FAILED_EXERCISES=''
 


### PR DESCRIPTION
Without the shebang, the buildscript might fail on environments which do
not use `bash` or a compatible shell as default.

This PR fixes the issue and makes the script more robust to the
environment.