### PR TITLE
Add a type signature for the wordCount function

### DIFF
--- a/exercises/word-count/WordCount.elm
+++ b/exercises/word-count/WordCount.elm
@@ -1,1 +1,4 @@
 module WordCount exposing (..)
+
+
+wordCount : String -> Dict String Int


### PR DESCRIPTION
Since the test converts wordCount’s output with Dict.toList, the required type may not be immediately apparent to an early learner.