### PR TITLE
Update to elm-test 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ language: bash
 sudo: false
 
 install:
-  - nvm install 0.12
-  - nvm use 0.12
-  - npm install -g elm@0.17.0 elm-test@0.16.1-alpha4
+  - nvm install 6
+  - nvm use 6
+  - npm install -g elm@0.17.1 elm-test@0.17.1
   - elm package install -y
 
 script:

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -12,7 +12,8 @@ do
   echo '-------------------------------------------------------'
   echo "Testing $exercise"
 
-  elm-make $exercise_dir/*Tests.elm --yes --output build.js && node build.js
+  elm-package install
+  elm-test $exercise_dir/*Tests.elm
 
   if [ $? -ne 0 ]; then
       TEST_RESULT=1

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,8 +2,8 @@
 
 The simplest way to install Elm is via Node.js/NPM.
 
-If you don't already have Node.js installed on your computer, you can download it from [the official site](https://nodejs.org/). Once you have Node.js up and running, follow these steps to install the Elm platform.
+If you don't already have Node.js installed on your computer, you can download it from [the official site](https://nodejs.org/). Once you have Node.js up and running, follow these steps to install the Elm platform and `elm-test`.
 
 ```bash
-$ npm install --global elm
+$ npm install --global elm elm-test
 ```

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,8 +1,8 @@
-Elm exercises within your exercism project directory can be run by changing to the exercise directory, and running `./runtests.sh` (or `runtests.bat` on Windows).
+The Elm exercise test suites may be run from the exercise directory.
 
 ```bash
 $ cd exercism/project/directory/elm/hello-world
-$ ./runtests.sh
+$ elm-test *Tests.elm
 ```
 
 ## Hints and tips

--- a/elm-package.json
+++ b/elm-package.json
@@ -36,8 +36,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/accumulate/AccumulateTests.elm
+++ b/exercises/accumulate/AccumulateTests.elm
@@ -1,6 +1,9 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Accumulate exposing (accumulate)
 import String
 
@@ -12,18 +15,21 @@ square x =
 
 tests : Test
 tests =
-    suite "Accumulate"
+    describe "Accumulate"
         [ test "[]] Accumulate"
-            (assertEqual [] (accumulate square []))
+            (\() -> Expect.equal [] (accumulate square []))
         , test "square Accumulate"
-            (assertEqual [ 1, 4, 9 ] (accumulate square [ 1, 2, 3 ]))
+            (\() -> Expect.equal [ 1, 4, 9 ] (accumulate square [ 1, 2, 3 ]))
         , test "toUpper Accumulate"
-            (assertEqual [ "HELLO", "WORLD" ] (accumulate String.toUpper [ "hello", "world" ]))
+            (\() -> Expect.equal [ "HELLO", "WORLD" ] (accumulate String.toUpper [ "hello", "world" ]))
         , test "reverse Accumulate"
-            (assertEqual [ "olleh", "dlrow" ] (accumulate String.reverse [ "hello", "world" ]))
+            (\() -> Expect.equal [ "olleh", "dlrow" ] (accumulate String.reverse [ "hello", "world" ]))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/accumulate/AccumulateTests.elm
+++ b/exercises/accumulate/AccumulateTests.elm
@@ -16,14 +16,18 @@ square x =
 tests : Test
 tests =
     describe "Accumulate"
-        [ test "[]] Accumulate"
-            (\() -> Expect.equal [] (accumulate square []))
-        , test "square Accumulate"
-            (\() -> Expect.equal [ 1, 4, 9 ] (accumulate square [ 1, 2, 3 ]))
-        , test "toUpper Accumulate"
-            (\() -> Expect.equal [ "HELLO", "WORLD" ] (accumulate String.toUpper [ "hello", "world" ]))
-        , test "reverse Accumulate"
-            (\() -> Expect.equal [ "olleh", "dlrow" ] (accumulate String.reverse [ "hello", "world" ]))
+        [ test "[]] Accumulate" <|
+            \() -> Expect.equal [] (accumulate square [])
+        , test "square Accumulate" <|
+            \() -> Expect.equal [ 1, 4, 9 ] (accumulate square [ 1, 2, 3 ])
+        , test "toUpper Accumulate" <|
+            \() ->
+                Expect.equal [ "HELLO", "WORLD" ]
+                    (accumulate String.toUpper [ "hello", "world" ])
+        , test "reverse Accumulate" <|
+            \() ->
+                Expect.equal [ "olleh", "dlrow" ]
+                    (accumulate String.reverse [ "hello", "world" ])
         ]
 
 

--- a/exercises/accumulate/elm-package.json
+++ b/exercises/accumulate/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/accumulate/runtests.bat
+++ b/exercises/accumulate/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/accumulate/runtests.sh
+++ b/exercises/accumulate/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/allergies/AllergiesTests.elm
+++ b/exercises/allergies/AllergiesTests.elm
@@ -1,47 +1,52 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Allergies exposing (isAllergicTo, toList)
 import List
 
 
 tests : Test
 tests =
-    suite "Allergies"
-        [ suite "isAllergicTo"
-            [ suite "no allergies means not allergic"
+    describe "Allergies"
+        [ describe "isAllergicTo"
+            [ describe "no allergies means not allergic"
                 [ test "peanuts"
-                    (assert (not (isAllergicTo "peanuts" 0)))
+                    (\() -> Expect.equal False (isAllergicTo "peanuts" 0))
                 , test "cats"
-                    (assert (not (isAllergicTo "cats" 0)))
+                    (\() -> Expect.equal False (isAllergicTo "cats" 0))
                 , test "strawberries"
-                    (assert (not (isAllergicTo "strawberries" 0)))
+                    (\() -> Expect.equal False (isAllergicTo "strawberries" 0))
                 ]
             , test "is allergic to eggs"
-                (assert (isAllergicTo "eggs" 1))
-            , suite "has the right allergies"
+                (\() -> Expect.equal True (isAllergicTo "eggs" 1))
+            , describe "has the right allergies"
                 [ test "eggs"
-                    (assert (isAllergicTo "eggs" 5))
+                    (\() -> Expect.equal True (isAllergicTo "eggs" 5))
                 , test "shellfish"
-                    (assert (isAllergicTo "shellfish" 5))
+                    (\() -> Expect.equal True (isAllergicTo "shellfish" 5))
                 , test "strawberries"
-                    (assert (not (isAllergicTo "strawberries" 5)))
+                    (\() -> Expect.equal True (not (isAllergicTo "strawberries" 5)))
                 ]
             ]
-        , suite "toList"
+        , describe "toList"
             [ test "no allergies at all"
-                (assertEqual [] (toList (0)))
+                (\() -> Expect.equal [] (toList (0)))
             , test "allergic to just peanuts"
-                (assertEqual [ "peanuts" ] (toList (2)))
+                (\() -> Expect.equal [ "peanuts" ] (toList (2)))
             , test "allergic to everything"
-                (assertEqual (List.sort [ "eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
-                    (255 |> toList |> List.sort)
+                (\() ->
+                    Expect.equal (List.sort [ "eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
+                        (255 |> toList |> List.sort)
                 )
             , test "ignore non allergen score parts"
-                (assertEqual [ "eggs" ] (toList 257))
+                (\() -> Expect.equal [ "eggs" ] (toList 257))
             , test "ignore non allergen score parts"
-                (assertEqual (List.sort [ "eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
-                    (509 |> toList |> List.sort)
+                (\() ->
+                    Expect.equal (List.sort [ "eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
+                        (509 |> toList |> List.sort)
                 )
             ]
         ]
@@ -49,4 +54,7 @@ tests =
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/allergies/AllergiesTests.elm
+++ b/exercises/allergies/AllergiesTests.elm
@@ -13,41 +13,39 @@ tests =
     describe "Allergies"
         [ describe "isAllergicTo"
             [ describe "no allergies means not allergic"
-                [ test "peanuts"
-                    (\() -> Expect.equal False (isAllergicTo "peanuts" 0))
-                , test "cats"
-                    (\() -> Expect.equal False (isAllergicTo "cats" 0))
-                , test "strawberries"
-                    (\() -> Expect.equal False (isAllergicTo "strawberries" 0))
+                [ test "peanuts" <|
+                    \() -> Expect.equal False (isAllergicTo "peanuts" 0)
+                , test "cats" <|
+                    \() -> Expect.equal False (isAllergicTo "cats" 0)
+                , test "strawberries" <|
+                    \() -> Expect.equal False (isAllergicTo "strawberries" 0)
                 ]
-            , test "is allergic to eggs"
-                (\() -> Expect.equal True (isAllergicTo "eggs" 1))
+            , test "is allergic to eggs" <|
+                \() -> Expect.equal True (isAllergicTo "eggs" 1)
             , describe "has the right allergies"
-                [ test "eggs"
-                    (\() -> Expect.equal True (isAllergicTo "eggs" 5))
-                , test "shellfish"
-                    (\() -> Expect.equal True (isAllergicTo "shellfish" 5))
-                , test "strawberries"
-                    (\() -> Expect.equal True (not (isAllergicTo "strawberries" 5)))
+                [ test "eggs" <|
+                    \() -> Expect.equal True (isAllergicTo "eggs" 5)
+                , test "shellfish" <|
+                    \() -> Expect.equal True (isAllergicTo "shellfish" 5)
+                , test "strawberries" <|
+                    \() -> Expect.equal False (isAllergicTo "strawberries" 5)
                 ]
             ]
         , describe "toList"
-            [ test "no allergies at all"
-                (\() -> Expect.equal [] (toList (0)))
-            , test "allergic to just peanuts"
-                (\() -> Expect.equal [ "peanuts" ] (toList (2)))
-            , test "allergic to everything"
-                (\() ->
+            [ test "no allergies at all" <|
+                \() -> Expect.equal [] (toList (0))
+            , test "allergic to just peanuts" <|
+                \() -> Expect.equal [ "peanuts" ] (toList (2))
+            , test "allergic to everything" <|
+                \() ->
                     Expect.equal (List.sort [ "eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
                         (255 |> toList |> List.sort)
-                )
-            , test "ignore non allergen score parts"
-                (\() -> Expect.equal [ "eggs" ] (toList 257))
-            , test "ignore non allergen score parts"
-                (\() ->
+            , test "ignore non allergen score parts" <|
+                \() -> Expect.equal [ "eggs" ] (toList 257)
+            , test "ignore non allergen score parts" <|
+                \() ->
                     Expect.equal (List.sort [ "eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
                         (509 |> toList |> List.sort)
-                )
             ]
         ]
 

--- a/exercises/allergies/elm-package.json
+++ b/exercises/allergies/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/allergies/runtests.bat
+++ b/exercises/allergies/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/allergies/runtests.sh
+++ b/exercises/allergies/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/anagram/AnagramTests.elm
+++ b/exercises/anagram/AnagramTests.elm
@@ -1,95 +1,121 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Anagram exposing (detect)
 
 
 tests : Test
 tests =
-    suite "Anagram"
+    describe "Anagram"
         [ test "no matches"
-            (assertEqual []
-                (detect "diaper" [ "hello", "world", "zombies", "pants" ])
+            (\() ->
+                Expect.equal []
+                    (detect "diaper" [ "hello", "world", "zombies", "pants" ])
             )
         , test "detects simple anagram"
-            (assertEqual [ "tan" ]
-                (detect "ant" [ "tan", "stand", "at" ])
+            (\() ->
+                Expect.equal [ "tan" ]
+                    (detect "ant" [ "tan", "stand", "at" ])
             )
         , test "does not detect false positives"
-            (assertEqual []
-                (detect "galea" [ "eagle" ])
+            (\() ->
+                Expect.equal []
+                    (detect "galea" [ "eagle" ])
             )
         , test "detects multiple anagrams"
-            (assertEqual [ "stream", "maters" ]
-                (detect "master" [ "stream", "pigeon", "maters" ])
+            (\() ->
+                Expect.equal [ "stream", "maters" ]
+                    (detect "master" [ "stream", "pigeon", "maters" ])
             )
         , test "does not detect anagram subsets"
-            (assertEqual []
-                (detect "good" [ "dog", "goody" ])
+            (\() ->
+                Expect.equal []
+                    (detect "good" [ "dog", "goody" ])
             )
         , test "detects anagram"
-            (assertEqual [ "inlets" ]
-                (detect "listen" [ "enlists", "google", "inlets", "banana" ])
+            (\() ->
+                Expect.equal [ "inlets" ]
+                    (detect "listen" [ "enlists", "google", "inlets", "banana" ])
             )
         , test "detects multiple anagrams"
-            (assertEqual [ "gallery", "regally", "largely" ]
-                (detect "allergy" [ "gallery", "ballerina", "regally", "clergy", "largely", "leading" ])
+            (\() ->
+                Expect.equal [ "gallery", "regally", "largely" ]
+                    (detect "allergy" [ "gallery", "ballerina", "regally", "clergy", "largely", "leading" ])
             )
         , test "does not detect indentical words"
-            (assertEqual [ "cron" ]
-                (detect "corn" [ "corn", "dark", "Corn", "rank", "CORN", "cron", "park" ])
+            (\() ->
+                Expect.equal [ "cron" ]
+                    (detect "corn" [ "corn", "dark", "Corn", "rank", "CORN", "cron", "park" ])
             )
         , test "does not detect non-anagrams with identical checksum"
-            (assertEqual []
-                (detect "mass" [ "last" ])
+            (\() ->
+                Expect.equal []
+                    (detect "mass" [ "last" ])
             )
         , test "detects anagrams case-insensitively"
-            (assertEqual [ "Carthorse" ]
-                (detect "Orchestra" [ "cashregister", "Carthorse", "radishes" ])
+            (\() ->
+                Expect.equal [ "Carthorse" ]
+                    (detect "Orchestra" [ "cashregister", "Carthorse", "radishes" ])
             )
         , test "detects anagrams using case-insensitive subject"
-            (assertEqual [ "carthorse" ]
-                (detect "Orchestra" [ "cashregister", "carthorse", "radishes" ])
+            (\() ->
+                Expect.equal [ "carthorse" ]
+                    (detect "Orchestra" [ "cashregister", "carthorse", "radishes" ])
             )
         , test "detects anagrams using case-insensitve possible matches"
-            (assertEqual [ "Carthorse" ]
-                (detect "orchestra" [ "cashregister", "Carthorse", "radishes" ])
+            (\() ->
+                Expect.equal [ "Carthorse" ]
+                    (detect "orchestra" [ "cashregister", "Carthorse", "radishes" ])
             )
         , test "does not detect a word as its own anagram"
-            (assertEqual []
-                (detect "banana" [ "Banana" ])
+            (\() ->
+                Expect.equal []
+                    (detect "banana" [ "Banana" ])
             )
         , test "does not detect a anagram if the original word is repeated"
-            (assertEqual []
-                (detect "go" [ "go Go GO" ])
+            (\() ->
+                Expect.equal []
+                    (detect "go" [ "go Go GO" ])
             )
         , test "anagrams must use all letters exactly once"
-            (assertEqual []
-                (detect "tapper" [ "patter" ])
+            (\() ->
+                Expect.equal []
+                    (detect "tapper" [ "patter" ])
             )
         , test "eliminates anagrams with the same checksum"
-            (assertEqual []
-                (detect "mass" [ "last" ])
+            (\() ->
+                Expect.equal []
+                    (detect "mass" [ "last" ])
             )
         , test "detects unicode anagrams"
-            (assertEqual [ "ΒΓΑ", "γβα" ]
-                (detect "ΑΒΓ" [ "ΒΓΑ", "ΒΓΔ", "γβα" ])
+            (\() ->
+                Expect.equal [ "ΒΓΑ", "γβα" ]
+                    (detect "ΑΒΓ" [ "ΒΓΑ", "ΒΓΔ", "γβα" ])
             )
         , test "eliminates misleading unicode anagrams"
-            (assertEqual []
-                (detect "ΑΒΓ" [ "ABΓ" ])
+            (\() ->
+                Expect.equal []
+                    (detect "ΑΒΓ" [ "ABΓ" ])
             )
         , test "capital word is not own anagram"
-            (assertEqual []
-                (detect "BANANA" [ "Banana" ])
+            (\() ->
+                Expect.equal []
+                    (detect "BANANA" [ "Banana" ])
             )
         , test "anagrams must use all letters exactly once"
-            (assertEqual []
-                (detect "patter" [ "tapper" ])
+            (\() ->
+                Expect.equal []
+                    (detect "patter" [ "tapper" ])
             )
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/anagram/AnagramTests.elm
+++ b/exercises/anagram/AnagramTests.elm
@@ -10,106 +10,86 @@ import Anagram exposing (detect)
 tests : Test
 tests =
     describe "Anagram"
-        [ test "no matches"
-            (\() ->
+        [ test "no matches" <|
+            \() ->
                 Expect.equal []
                     (detect "diaper" [ "hello", "world", "zombies", "pants" ])
-            )
-        , test "detects simple anagram"
-            (\() ->
+        , test "detects simple anagram" <|
+            \() ->
                 Expect.equal [ "tan" ]
                     (detect "ant" [ "tan", "stand", "at" ])
-            )
-        , test "does not detect false positives"
-            (\() ->
+        , test "does not detect false positives" <|
+            \() ->
                 Expect.equal []
                     (detect "galea" [ "eagle" ])
-            )
-        , test "detects multiple anagrams"
-            (\() ->
+        , test "detects multiple anagrams" <|
+            \() ->
                 Expect.equal [ "stream", "maters" ]
                     (detect "master" [ "stream", "pigeon", "maters" ])
-            )
-        , test "does not detect anagram subsets"
-            (\() ->
+        , test "does not detect anagram subsets" <|
+            \() ->
                 Expect.equal []
                     (detect "good" [ "dog", "goody" ])
-            )
-        , test "detects anagram"
-            (\() ->
+        , test "detects anagram" <|
+            \() ->
                 Expect.equal [ "inlets" ]
                     (detect "listen" [ "enlists", "google", "inlets", "banana" ])
-            )
-        , test "detects multiple anagrams"
-            (\() ->
+        , test "detects multiple anagrams" <|
+            \() ->
                 Expect.equal [ "gallery", "regally", "largely" ]
                     (detect "allergy" [ "gallery", "ballerina", "regally", "clergy", "largely", "leading" ])
-            )
-        , test "does not detect indentical words"
-            (\() ->
+        , test "does not detect indentical words" <|
+            \() ->
                 Expect.equal [ "cron" ]
                     (detect "corn" [ "corn", "dark", "Corn", "rank", "CORN", "cron", "park" ])
-            )
-        , test "does not detect non-anagrams with identical checksum"
-            (\() ->
+        , test "does not detect non-anagrams with identical checksum" <|
+            \() ->
                 Expect.equal []
                     (detect "mass" [ "last" ])
-            )
-        , test "detects anagrams case-insensitively"
-            (\() ->
+        , test "detects anagrams case-insensitively" <|
+            \() ->
                 Expect.equal [ "Carthorse" ]
                     (detect "Orchestra" [ "cashregister", "Carthorse", "radishes" ])
-            )
-        , test "detects anagrams using case-insensitive subject"
-            (\() ->
+        , test "detects anagrams using case-insensitive subject" <|
+            \() ->
                 Expect.equal [ "carthorse" ]
                     (detect "Orchestra" [ "cashregister", "carthorse", "radishes" ])
-            )
-        , test "detects anagrams using case-insensitve possible matches"
-            (\() ->
+        , test "detects anagrams using case-insensitve possible matches" <|
+            \() ->
                 Expect.equal [ "Carthorse" ]
                     (detect "orchestra" [ "cashregister", "Carthorse", "radishes" ])
-            )
-        , test "does not detect a word as its own anagram"
-            (\() ->
+        , test "does not detect a word as its own anagram" <|
+            \() ->
                 Expect.equal []
                     (detect "banana" [ "Banana" ])
-            )
-        , test "does not detect a anagram if the original word is repeated"
-            (\() ->
+        , test "does not detect a anagram if the original word is repeated" <|
+            \() ->
                 Expect.equal []
                     (detect "go" [ "go Go GO" ])
-            )
-        , test "anagrams must use all letters exactly once"
-            (\() ->
+        , test "anagrams must use all letters exactly once" <|
+            \() ->
                 Expect.equal []
                     (detect "tapper" [ "patter" ])
-            )
-        , test "eliminates anagrams with the same checksum"
-            (\() ->
+        , test "eliminates anagrams with the same checksum" <|
+            \() ->
                 Expect.equal []
                     (detect "mass" [ "last" ])
-            )
-        , test "detects unicode anagrams"
-            (\() ->
+        , test "detects unicode anagrams" <|
+            \() ->
                 Expect.equal [ "ΒΓΑ", "γβα" ]
                     (detect "ΑΒΓ" [ "ΒΓΑ", "ΒΓΔ", "γβα" ])
-            )
-        , test "eliminates misleading unicode anagrams"
-            (\() ->
+        , test "eliminates misleading unicode anagrams" <|
+            \() ->
                 Expect.equal []
                     (detect "ΑΒΓ" [ "ABΓ" ])
-            )
-        , test "capital word is not own anagram"
-            (\() ->
+        , test "capital word is not own anagram" <|
+            \() ->
                 Expect.equal []
                     (detect "BANANA" [ "Banana" ])
-            )
-        , test "anagrams must use all letters exactly once"
-            (\() ->
+        , test "anagrams must use all letters exactly once" <|
+            \() ->
                 Expect.equal []
                     (detect "patter" [ "tapper" ])
-            )
         ]
 
 

--- a/exercises/anagram/elm-package.json
+++ b/exercises/anagram/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/anagram/runtests.bat
+++ b/exercises/anagram/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/anagram/runtests.sh
+++ b/exercises/anagram/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/atbash-cipher/AtbashCipherTests.elm
+++ b/exercises/atbash-cipher/AtbashCipherTests.elm
@@ -10,32 +10,30 @@ import AtbashCipher exposing (encode, decode)
 tests : Test
 tests =
     describe "AtbashCipher"
-        [ test "encode no"
-            (\() -> Expect.equal "ml" (encode "no"))
-        , test "encode yes"
-            (\() -> Expect.equal "bvh" (encode "yes"))
-        , test "encode OMG"
-            (\() -> Expect.equal "lnt" (encode "OMG"))
-        , test "encode O M G"
-            (\() -> Expect.equal "lnt" (encode "O M G"))
-        , test "encode long word"
-            (\() -> Expect.equal "nrmwy oldrm tob" (encode "mindblowingly"))
-        , test "encode numbers"
-            (\() -> Expect.equal "gvhgr mt123 gvhgr mt" (encode "Testing, 1 2 3, testing."))
-        , test "encode sentence"
-            (\() -> Expect.equal "gifgs rhurx grlm" (encode "Truth is fiction."))
-        , test "encode all things"
-            (\() ->
+        [ test "encode no" <|
+            \() -> Expect.equal "ml" (encode "no")
+        , test "encode yes" <|
+            \() -> Expect.equal "bvh" (encode "yes")
+        , test "encode OMG" <|
+            \() -> Expect.equal "lnt" (encode "OMG")
+        , test "encode O M G" <|
+            \() -> Expect.equal "lnt" (encode "O M G")
+        , test "encode long word" <|
+            \() -> Expect.equal "nrmwy oldrm tob" (encode "mindblowingly")
+        , test "encode numbers" <|
+            \() -> Expect.equal "gvhgr mt123 gvhgr mt" (encode "Testing, 1 2 3, testing.")
+        , test "encode sentence" <|
+            \() -> Expect.equal "gifgs rhurx grlm" (encode "Truth is fiction.")
+        , test "encode all things" <|
+            \() ->
                 Expect.equal "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
                     (encode "The quick brown fox jumps over the lazy dog.")
-            )
-        , test "decode word"
-            (\() -> Expect.equal "exercism" (decode "vcvix rhn"))
-        , test "decode sentence"
-            (\() ->
+        , test "decode word" <|
+            \() -> Expect.equal "exercism" (decode "vcvix rhn")
+        , test "decode sentence" <|
+            \() ->
                 Expect.equal "anobstacleisoftenasteppingstone"
                     (decode "zmlyh gzxov rhlug vmzhg vkkrm thglm v")
-            )
         ]
 
 

--- a/exercises/atbash-cipher/AtbashCipherTests.elm
+++ b/exercises/atbash-cipher/AtbashCipherTests.elm
@@ -1,39 +1,47 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import AtbashCipher exposing (encode, decode)
 
 
 tests : Test
 tests =
-    suite "AtbashCipher"
+    describe "AtbashCipher"
         [ test "encode no"
-            (assertEqual "ml" (encode "no"))
+            (\() -> Expect.equal "ml" (encode "no"))
         , test "encode yes"
-            (assertEqual "bvh" (encode "yes"))
+            (\() -> Expect.equal "bvh" (encode "yes"))
         , test "encode OMG"
-            (assertEqual "lnt" (encode "OMG"))
+            (\() -> Expect.equal "lnt" (encode "OMG"))
         , test "encode O M G"
-            (assertEqual "lnt" (encode "O M G"))
+            (\() -> Expect.equal "lnt" (encode "O M G"))
         , test "encode long word"
-            (assertEqual "nrmwy oldrm tob" (encode "mindblowingly"))
+            (\() -> Expect.equal "nrmwy oldrm tob" (encode "mindblowingly"))
         , test "encode numbers"
-            (assertEqual "gvhgr mt123 gvhgr mt" (encode "Testing, 1 2 3, testing."))
+            (\() -> Expect.equal "gvhgr mt123 gvhgr mt" (encode "Testing, 1 2 3, testing."))
         , test "encode sentence"
-            (assertEqual "gifgs rhurx grlm" (encode "Truth is fiction."))
+            (\() -> Expect.equal "gifgs rhurx grlm" (encode "Truth is fiction."))
         , test "encode all things"
-            (assertEqual "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
-                (encode "The quick brown fox jumps over the lazy dog.")
+            (\() ->
+                Expect.equal "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+                    (encode "The quick brown fox jumps over the lazy dog.")
             )
         , test "decode word"
-            (assertEqual "exercism" (decode "vcvix rhn"))
+            (\() -> Expect.equal "exercism" (decode "vcvix rhn"))
         , test "decode sentence"
-            (assertEqual "anobstacleisoftenasteppingstone"
-                (decode "zmlyh gzxov rhlug vmzhg vkkrm thglm v")
+            (\() ->
+                Expect.equal "anobstacleisoftenasteppingstone"
+                    (decode "zmlyh gzxov rhlug vmzhg vkkrm thglm v")
             )
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/atbash-cipher/elm-package.json
+++ b/exercises/atbash-cipher/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/atbash-cipher/runtests.bat
+++ b/exercises/atbash-cipher/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/atbash-cipher/runtests.sh
+++ b/exercises/atbash-cipher/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/bob/BobTests.elm
+++ b/exercises/bob/BobTests.elm
@@ -13,26 +13,105 @@ import Bob
 tests : Test
 tests =
     describe "Bob"
-        [ test "stating something" (\() -> Expect.equal "Whatever." (Bob.hey "Tom-ay-to, tom-aaaah-to."))
-        , test "shouting" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "WATCH OUT!"))
-        , test "shouting gibberish" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey (uppercaseGibberish 10)))
-        , test "asking a question" (\() -> Expect.equal "Sure." (Bob.hey "Does this cryogenic chamber make me look fat?"))
-        , test "asking a numeric question" (\() -> Expect.equal "Sure." (Bob.hey "You are, what, like 15?"))
-        , test "asking gibberish" (\() -> Expect.equal "Sure." (Bob.hey (gibberishQuestion 20)))
-        , test "talking forcefully" (\() -> Expect.equal "Whatever." (Bob.hey "Let's go make out behind the gym!"))
-        , test "using acronyms in regular speech" (\() -> Expect.equal "Whatever." (Bob.hey "It's OK if you don't want to go to the DMV."))
-        , test "forceful questions" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "WHAT THE HELL WERE YOU THINKING?"))
-        , test "shouting numbers" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "1, 2, 3 GO!"))
-        , test "only numbers" (\() -> Expect.equal "Whatever." (Bob.hey "1, 2, 3"))
-        , test "question with only numbers" (\() -> Expect.equal "Sure." (Bob.hey "4?"))
-        , test "shouting with special characters" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!)"))
-        , test "shouting with no exclamation mark" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "I HATE YOU"))
-        , test "statement containing a question mark" (\() -> Expect.equal "Whatever." (Bob.hey "Ending with ? means a question."))
-        , test "prattling on" (\() -> Expect.equal "Sure." (Bob.hey "Wait! Hang on. Are you going to be OK?"))
-        , test "silence" (\() -> Expect.equal "Fine. Be that way!" (Bob.hey ""))
-        , test "prolonged silence" (\() -> Expect.equal "Fine. Be that way!" (Bob.hey "       "))
-        , test "alternate silences" (\() -> Expect.equal "Fine. Be that way!" (Bob.hey "\t  \n  \t   "))
-        , test "on multiple line questions" (\() -> Expect.equal "Whatever." (Bob.hey "\nDoes this cryogenic chamber make me look fat?\nno"))
+        [ test "stating something" <|
+            \() ->
+                Expect.equal "Whatever."
+                    (Bob.hey "Tom-ay-to, tom-aaaah-to.")
+        , test "shouting" <|
+            \() ->
+                Expect.equal
+                    "Whoa, chill out!"
+                    (Bob.hey "WATCH OUT!")
+        , test "shouting gibberish" <|
+            \() ->
+                Expect.equal
+                    "Whoa, chill out!"
+                    (Bob.hey (uppercaseGibberish 10))
+        , test "asking a question" <|
+            \() ->
+                Expect.equal
+                    "Sure."
+                    (Bob.hey "Does this cryogenic chamber make me look fat?")
+        , test "asking a numeric question" <|
+            \() ->
+                Expect.equal
+                    "Sure."
+                    (Bob.hey "You are, what, like 15?")
+        , test "asking gibberish" <|
+            \() ->
+                Expect.equal
+                    "Sure."
+                    (Bob.hey (gibberishQuestion 20))
+        , test "talking forcefully" <|
+            \() ->
+                Expect.equal
+                    "Whatever."
+                    (Bob.hey "Let's go make out behind the gym!")
+        , test "using acronyms in regular speech" <|
+            \() ->
+                Expect.equal
+                    "Whatever."
+                    (Bob.hey "It's OK if you don't want to go to the DMV.")
+        , test "forceful questions" <|
+            \() ->
+                Expect.equal
+                    "Whoa, chill out!"
+                    (Bob.hey "WHAT THE HELL WERE YOU THINKING?")
+        , test "shouting numbers" <|
+            \() ->
+                Expect.equal
+                    "Whoa, chill out!"
+                    (Bob.hey "1, 2, 3 GO!")
+        , test "only numbers" <|
+            \() ->
+                Expect.equal
+                    "Whatever."
+                    (Bob.hey "1, 2, 3")
+        , test "question with only numbers" <|
+            \() ->
+                Expect.equal
+                    "Sure."
+                    (Bob.hey "4?")
+        , test "shouting with special characters" <|
+            \() ->
+                Expect.equal
+                    "Whoa, chill out!"
+                    (Bob.hey "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!)")
+        , test "shouting with no exclamation mark" <|
+            \() ->
+                Expect.equal
+                    "Whoa, chill out!"
+                    (Bob.hey "I HATE YOU")
+        , test "statement containing a question mark" <|
+            \() ->
+                Expect.equal
+                    "Whatever."
+                    (Bob.hey "Ending with ? means a question.")
+        , test "prattling on" <|
+            \() ->
+                Expect.equal
+                    "Sure."
+                    (Bob.hey "Wait! Hang on. Are you going to be OK?")
+        , test "silence" <|
+            \() ->
+                Expect.equal
+                    "Fine. Be that way!"
+                    (Bob.hey "")
+        , test "prolonged silence" <|
+            \() ->
+                Expect.equal
+                    "Fine. Be that way!"
+                    (Bob.hey "       ")
+        , test "alternate silences" <|
+            \() ->
+                Expect.equal
+                    "Fine. Be that way!"
+                    (Bob.hey "\t  \n  \t   ")
+        , test "on multiple line questions" <|
+            \() ->
+                Expect.equal
+                    "Whatever."
+                    (Bob.hey "\nDoes this cryogenic chamber make me look fat?\nno")
         ]
 
 

--- a/exercises/bob/BobTests.elm
+++ b/exercises/bob/BobTests.elm
@@ -1,6 +1,9 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import String
 import Char
 import Random
@@ -9,27 +12,27 @@ import Bob
 
 tests : Test
 tests =
-    suite "Bob"
-        [ test "stating something" (assertEqual "Whatever." (Bob.hey "Tom-ay-to, tom-aaaah-to."))
-        , test "shouting" (assertEqual "Whoa, chill out!" (Bob.hey "WATCH OUT!"))
-        , test "shouting gibberish" (assertEqual "Whoa, chill out!" (Bob.hey (uppercaseGibberish 10)))
-        , test "asking a question" (assertEqual "Sure." (Bob.hey "Does this cryogenic chamber make me look fat?"))
-        , test "asking a numeric question" (assertEqual "Sure." (Bob.hey "You are, what, like 15?"))
-        , test "asking gibberish" (assertEqual "Sure." (Bob.hey (gibberishQuestion 20)))
-        , test "talking forcefully" (assertEqual "Whatever." (Bob.hey "Let's go make out behind the gym!"))
-        , test "using acronyms in regular speech" (assertEqual "Whatever." (Bob.hey "It's OK if you don't want to go to the DMV."))
-        , test "forceful questions" (assertEqual "Whoa, chill out!" (Bob.hey "WHAT THE HELL WERE YOU THINKING?"))
-        , test "shouting numbers" (assertEqual "Whoa, chill out!" (Bob.hey "1, 2, 3 GO!"))
-        , test "only numbers" (assertEqual "Whatever." (Bob.hey "1, 2, 3"))
-        , test "question with only numbers" (assertEqual "Sure." (Bob.hey "4?"))
-        , test "shouting with special characters" (assertEqual "Whoa, chill out!" (Bob.hey "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!)"))
-        , test "shouting with no exclamation mark" (assertEqual "Whoa, chill out!" (Bob.hey "I HATE YOU"))
-        , test "statement containing a question mark" (assertEqual "Whatever." (Bob.hey "Ending with ? means a question."))
-        , test "prattling on" (assertEqual "Sure." (Bob.hey "Wait! Hang on. Are you going to be OK?"))
-        , test "silence" (assertEqual "Fine. Be that way!" (Bob.hey ""))
-        , test "prolonged silence" (assertEqual "Fine. Be that way!" (Bob.hey "       "))
-        , test "alternate silences" (assertEqual "Fine. Be that way!" (Bob.hey "\t  \n  \t   "))
-        , test "on multiple line questions" (assertEqual "Whatever." (Bob.hey "\nDoes this cryogenic chamber make me look fat?\nno"))
+    describe "Bob"
+        [ test "stating something" (\() -> Expect.equal "Whatever." (Bob.hey "Tom-ay-to, tom-aaaah-to."))
+        , test "shouting" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "WATCH OUT!"))
+        , test "shouting gibberish" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey (uppercaseGibberish 10)))
+        , test "asking a question" (\() -> Expect.equal "Sure." (Bob.hey "Does this cryogenic chamber make me look fat?"))
+        , test "asking a numeric question" (\() -> Expect.equal "Sure." (Bob.hey "You are, what, like 15?"))
+        , test "asking gibberish" (\() -> Expect.equal "Sure." (Bob.hey (gibberishQuestion 20)))
+        , test "talking forcefully" (\() -> Expect.equal "Whatever." (Bob.hey "Let's go make out behind the gym!"))
+        , test "using acronyms in regular speech" (\() -> Expect.equal "Whatever." (Bob.hey "It's OK if you don't want to go to the DMV."))
+        , test "forceful questions" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "WHAT THE HELL WERE YOU THINKING?"))
+        , test "shouting numbers" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "1, 2, 3 GO!"))
+        , test "only numbers" (\() -> Expect.equal "Whatever." (Bob.hey "1, 2, 3"))
+        , test "question with only numbers" (\() -> Expect.equal "Sure." (Bob.hey "4?"))
+        , test "shouting with special characters" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!)"))
+        , test "shouting with no exclamation mark" (\() -> Expect.equal "Whoa, chill out!" (Bob.hey "I HATE YOU"))
+        , test "statement containing a question mark" (\() -> Expect.equal "Whatever." (Bob.hey "Ending with ? means a question."))
+        , test "prattling on" (\() -> Expect.equal "Sure." (Bob.hey "Wait! Hang on. Are you going to be OK?"))
+        , test "silence" (\() -> Expect.equal "Fine. Be that way!" (Bob.hey ""))
+        , test "prolonged silence" (\() -> Expect.equal "Fine. Be that way!" (Bob.hey "       "))
+        , test "alternate silences" (\() -> Expect.equal "Fine. Be that way!" (Bob.hey "\t  \n  \t   "))
+        , test "on multiple line questions" (\() -> Expect.equal "Whatever." (Bob.hey "\nDoes this cryogenic chamber make me look fat?\nno"))
         ]
 
 
@@ -70,4 +73,7 @@ gibberishQuestion length =
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/bob/elm-package.json
+++ b/exercises/bob/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/bob/runtests.bat
+++ b/exercises/bob/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/bob/runtests.sh
+++ b/exercises/bob/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/difference-of-squares/DifferenceOfSquaresTests.elm
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTests.elm
@@ -11,20 +11,30 @@ tests : Test
 tests =
     describe "DifferenceOfSquares"
         [ describe "square the sum of the numbers up to the given number"
-            [ test "square of sum 5" (\() -> Expect.equal 225 (squareOfSum 5))
-            , test "square of sum 10" (\() -> Expect.equal 3025 (squareOfSum 10))
-            , test "square of sum 100" (\() -> Expect.equal 25502500 (squareOfSum 100))
+            [ test "square of sum 5" <|
+                \() -> Expect.equal 225 (squareOfSum 5)
+            , test "square of sum 10" <|
+                \() -> Expect.equal 3025 (squareOfSum 10)
+            , test "square of sum 100" <|
+                \() -> Expect.equal 25502500 (squareOfSum 100)
             ]
         , describe "sum the squares of the numbers up to the given number"
-            [ test "sum of squares 5" (\() -> Expect.equal 55 (sumOfSquares 5))
-            , test "sum of squares 10" (\() -> Expect.equal 385 (sumOfSquares 10))
-            , test "sum of squares 100" (\() -> Expect.equal 338350 (sumOfSquares 100))
+            [ test "sum of squares 5" <|
+                \() -> Expect.equal 55 (sumOfSquares 5)
+            , test "sum of squares 10" <|
+                \() -> Expect.equal 385 (sumOfSquares 10)
+            , test "sum of squares 100" <|
+                \() -> Expect.equal 338350 (sumOfSquares 100)
             ]
         , describe "subtract sum of squares from square of sums"
-            [ test "difference of squares 0" (\() -> Expect.equal 0 (difference 0))
-            , test "difference of squares 5" (\() -> Expect.equal 170 (difference 5))
-            , test "difference of squares 10" (\() -> Expect.equal 2640 (difference 10))
-            , test "difference of squares 100" (\() -> Expect.equal 25164150 (difference 100))
+            [ test "difference of squares 0" <|
+                \() -> Expect.equal 0 (difference 0)
+            , test "difference of squares 5" <|
+                \() -> Expect.equal 170 (difference 5)
+            , test "difference of squares 10" <|
+                \() -> Expect.equal 2640 (difference 10)
+            , test "difference of squares 100" <|
+                \() -> Expect.equal 25164150 (difference 100)
             ]
         ]
 

--- a/exercises/difference-of-squares/DifferenceOfSquaresTests.elm
+++ b/exercises/difference-of-squares/DifferenceOfSquaresTests.elm
@@ -1,31 +1,37 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import DifferenceOfSquares exposing (squareOfSum, sumOfSquares, difference)
 
 
 tests : Test
 tests =
-    suite "DifferenceOfSquares"
-        [ suite "square the sum of the numbers up to the given number"
-            [ test "square of sum 5" (assertEqual 225 (squareOfSum 5))
-            , test "square of sum 10" (assertEqual 3025 (squareOfSum 10))
-            , test "square of sum 100" (assertEqual 25502500 (squareOfSum 100))
+    describe "DifferenceOfSquares"
+        [ describe "square the sum of the numbers up to the given number"
+            [ test "square of sum 5" (\() -> Expect.equal 225 (squareOfSum 5))
+            , test "square of sum 10" (\() -> Expect.equal 3025 (squareOfSum 10))
+            , test "square of sum 100" (\() -> Expect.equal 25502500 (squareOfSum 100))
             ]
-        , suite "sum the squares of the numbers up to the given number"
-            [ test "sum of squares 5" (assertEqual 55 (sumOfSquares 5))
-            , test "sum of squares 10" (assertEqual 385 (sumOfSquares 10))
-            , test "sum of squares 100" (assertEqual 338350 (sumOfSquares 100))
+        , describe "sum the squares of the numbers up to the given number"
+            [ test "sum of squares 5" (\() -> Expect.equal 55 (sumOfSquares 5))
+            , test "sum of squares 10" (\() -> Expect.equal 385 (sumOfSquares 10))
+            , test "sum of squares 100" (\() -> Expect.equal 338350 (sumOfSquares 100))
             ]
-        , suite "subtract sum of squares from square of sums"
-            [ test "difference of squares 0" (assertEqual 0 (difference 0))
-            , test "difference of squares 5" (assertEqual 170 (difference 5))
-            , test "difference of squares 10" (assertEqual 2640 (difference 10))
-            , test "difference of squares 100" (assertEqual 25164150 (difference 100))
+        , describe "subtract sum of squares from square of sums"
+            [ test "difference of squares 0" (\() -> Expect.equal 0 (difference 0))
+            , test "difference of squares 5" (\() -> Expect.equal 170 (difference 5))
+            , test "difference of squares 10" (\() -> Expect.equal 2640 (difference 10))
+            , test "difference of squares 100" (\() -> Expect.equal 25164150 (difference 100))
             ]
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/difference-of-squares/elm-package.json
+++ b/exercises/difference-of-squares/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/difference-of-squares/runtests.bat
+++ b/exercises/difference-of-squares/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/difference-of-squares/runtests.sh
+++ b/exercises/difference-of-squares/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/grade-school/GradeSchoolTests.elm
+++ b/exercises/grade-school/GradeSchoolTests.elm
@@ -10,16 +10,15 @@ import GradeSchool exposing (addStudent, studentsInGrade, allStudents)
 tests : Test
 tests =
     describe "GradeSchool"
-        [ test "add student"
-            (\() ->
+        [ test "add student" <|
+            \() ->
                 Expect.equal [ "Aimee" ]
                     (GradeSchool.empty
                         |> addStudent 2 "Aimee"
                         |> studentsInGrade 2
                     )
-            )
-        , test "add more students in same class"
-            (\() ->
+        , test "add more students in same class" <|
+            \() ->
                 Expect.equal [ "Blair", "James", "Paul" ]
                     (GradeSchool.empty
                         |> addStudent 2 "James"
@@ -27,9 +26,8 @@ tests =
                         |> addStudent 2 "Paul"
                         |> studentsInGrade 2
                     )
-            )
-        , test "add students to different grades"
-            (\() ->
+        , test "add students to different grades" <|
+            \() ->
                 Expect.equal [ [ "Chelsea" ], [ "Logan" ] ]
                     (let
                         school =
@@ -39,9 +37,8 @@ tests =
                      in
                         [ studentsInGrade 3 school, studentsInGrade 7 school ]
                     )
-            )
-        , test "get students in a grade"
-            (\() ->
+        , test "get students in a grade" <|
+            \() ->
                 Expect.equal [ "Bradley", "Franklin" ]
                     (GradeSchool.empty
                         |> addStudent 5 "Franklin"
@@ -49,9 +46,8 @@ tests =
                         |> addStudent 1 "Jeff"
                         |> studentsInGrade 5
                     )
-            )
-        , test "get all students in the school"
-            (\() ->
+        , test "get all students in the school" <|
+            \() ->
                 Expect.equal [ ( 3, [ "Kyle" ] ), ( 4, [ "Christopher", "Jennifer" ] ), ( 6, [ "Kareem" ] ) ]
                     (GradeSchool.empty
                         |> addStudent 4 "Jennifer"
@@ -60,9 +56,8 @@ tests =
                         |> addStudent 3 "Kyle"
                         |> allStudents
                     )
-            )
-        , test "get students in a non-existent grade"
-            (\() -> Expect.equal [] (studentsInGrade 1 GradeSchool.empty))
+        , test "get students in a non-existent grade" <|
+            \() -> Expect.equal [] (studentsInGrade 1 GradeSchool.empty)
         ]
 
 

--- a/exercises/grade-school/GradeSchoolTests.elm
+++ b/exercises/grade-school/GradeSchoolTests.elm
@@ -1,63 +1,74 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import GradeSchool exposing (addStudent, studentsInGrade, allStudents)
 
 
 tests : Test
 tests =
-    suite "GradeSchool"
+    describe "GradeSchool"
         [ test "add student"
-            (assertEqual [ "Aimee" ]
-                (GradeSchool.empty
-                    |> addStudent 2 "Aimee"
-                    |> studentsInGrade 2
-                )
+            (\() ->
+                Expect.equal [ "Aimee" ]
+                    (GradeSchool.empty
+                        |> addStudent 2 "Aimee"
+                        |> studentsInGrade 2
+                    )
             )
         , test "add more students in same class"
-            (assertEqual [ "Blair", "James", "Paul" ]
-                (GradeSchool.empty
-                    |> addStudent 2 "James"
-                    |> addStudent 2 "Blair"
-                    |> addStudent 2 "Paul"
-                    |> studentsInGrade 2
-                )
+            (\() ->
+                Expect.equal [ "Blair", "James", "Paul" ]
+                    (GradeSchool.empty
+                        |> addStudent 2 "James"
+                        |> addStudent 2 "Blair"
+                        |> addStudent 2 "Paul"
+                        |> studentsInGrade 2
+                    )
             )
         , test "add students to different grades"
-            (assertEqual [ [ "Chelsea" ], [ "Logan" ] ]
-                (let
-                    school =
-                        GradeSchool.empty
-                            |> addStudent 3 "Chelsea"
-                            |> addStudent 7 "Logan"
-                 in
-                    [ studentsInGrade 3 school, studentsInGrade 7 school ]
-                )
+            (\() ->
+                Expect.equal [ [ "Chelsea" ], [ "Logan" ] ]
+                    (let
+                        school =
+                            GradeSchool.empty
+                                |> addStudent 3 "Chelsea"
+                                |> addStudent 7 "Logan"
+                     in
+                        [ studentsInGrade 3 school, studentsInGrade 7 school ]
+                    )
             )
         , test "get students in a grade"
-            (assertEqual [ "Bradley", "Franklin" ]
-                (GradeSchool.empty
-                    |> addStudent 5 "Franklin"
-                    |> addStudent 5 "Bradley"
-                    |> addStudent 1 "Jeff"
-                    |> studentsInGrade 5
-                )
+            (\() ->
+                Expect.equal [ "Bradley", "Franklin" ]
+                    (GradeSchool.empty
+                        |> addStudent 5 "Franklin"
+                        |> addStudent 5 "Bradley"
+                        |> addStudent 1 "Jeff"
+                        |> studentsInGrade 5
+                    )
             )
         , test "get all students in the school"
-            (assertEqual [ ( 3, [ "Kyle" ] ), ( 4, [ "Christopher", "Jennifer" ] ), ( 6, [ "Kareem" ] ) ]
-                (GradeSchool.empty
-                    |> addStudent 4 "Jennifer"
-                    |> addStudent 6 "Kareem"
-                    |> addStudent 4 "Christopher"
-                    |> addStudent 3 "Kyle"
-                    |> allStudents
-                )
+            (\() ->
+                Expect.equal [ ( 3, [ "Kyle" ] ), ( 4, [ "Christopher", "Jennifer" ] ), ( 6, [ "Kareem" ] ) ]
+                    (GradeSchool.empty
+                        |> addStudent 4 "Jennifer"
+                        |> addStudent 6 "Kareem"
+                        |> addStudent 4 "Christopher"
+                        |> addStudent 3 "Kyle"
+                        |> allStudents
+                    )
             )
         , test "get students in a non-existent grade"
-            (assertEqual [] (studentsInGrade 1 GradeSchool.empty))
+            (\() -> Expect.equal [] (studentsInGrade 1 GradeSchool.empty))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/grade-school/elm-package.json
+++ b/exercises/grade-school/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/grade-school/runtests.bat
+++ b/exercises/grade-school/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/grade-school/runtests.sh
+++ b/exercises/grade-school/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/hamming/HammingTests.elm
+++ b/exercises/hamming/HammingTests.elm
@@ -1,43 +1,49 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Hamming exposing (distance)
 
 
 tests : Test
 tests =
-    suite "Hamming"
+    describe "Hamming"
         [ test "identical strands"
-            (assertEqual (Just 0) (distance "A" "A"))
+            (\() -> Expect.equal (Just 0) (distance "A" "A"))
         , test "long identical strands"
-            (assertEqual (Just 0) (distance "GGACTGA" "GGACTGA"))
+            (\() -> Expect.equal (Just 0) (distance "GGACTGA" "GGACTGA"))
         , test "complete distance in single nucleotide strands"
-            (assertEqual (Just 1) (distance "A" "G"))
+            (\() -> Expect.equal (Just 1) (distance "A" "G"))
         , test "complete distance in small strands"
-            (assertEqual (Just 2) (distance "AG" "CT"))
+            (\() -> Expect.equal (Just 2) (distance "AG" "CT"))
         , test "small distance in small strands"
-            (assertEqual (Just 1) (distance "AT" "CT"))
+            (\() -> Expect.equal (Just 1) (distance "AT" "CT"))
         , test "small distance"
-            (assertEqual (Just 1) (distance "GGACG" "GGTCG"))
+            (\() -> Expect.equal (Just 1) (distance "GGACG" "GGTCG"))
         , test "small distance in long strands"
-            (assertEqual (Just 2) (distance "ACCAGGG" "ACTATGG"))
+            (\() -> Expect.equal (Just 2) (distance "ACCAGGG" "ACTATGG"))
         , test "non-unique character in first strand"
-            (assertEqual (Just 1) (distance "AGA" "AGG"))
+            (\() -> Expect.equal (Just 1) (distance "AGA" "AGG"))
         , test "non-unique character in second strand"
-            (assertEqual (Just 1) (distance "AGG" "AGA"))
+            (\() -> Expect.equal (Just 1) (distance "AGG" "AGA"))
         , test "large distance"
-            (assertEqual (Just 4) (distance "GATACA" "GCATAA"))
+            (\() -> Expect.equal (Just 4) (distance "GATACA" "GCATAA"))
         , test "large distance in off-by-one strand"
-            (assertEqual (Just 9) (distance "GGACGGATTCTG" "AGGACGGATTCT"))
+            (\() -> Expect.equal (Just 9) (distance "GGACGGATTCTG" "AGGACGGATTCT"))
         , test "empty strands"
-            (assertEqual (Just 0) (distance "" ""))
+            (\() -> Expect.equal (Just 0) (distance "" ""))
         , test "disallow first strand longer"
-            (assertEqual Nothing (distance "AATG" "AAA"))
+            (\() -> Expect.equal Nothing (distance "AATG" "AAA"))
         , test "disallow second strand longer"
-            (assertEqual Nothing (distance "ATA" "AGTG"))
+            (\() -> Expect.equal Nothing (distance "ATA" "AGTG"))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/hamming/HammingTests.elm
+++ b/exercises/hamming/HammingTests.elm
@@ -10,34 +10,34 @@ import Hamming exposing (distance)
 tests : Test
 tests =
     describe "Hamming"
-        [ test "identical strands"
-            (\() -> Expect.equal (Just 0) (distance "A" "A"))
-        , test "long identical strands"
-            (\() -> Expect.equal (Just 0) (distance "GGACTGA" "GGACTGA"))
-        , test "complete distance in single nucleotide strands"
-            (\() -> Expect.equal (Just 1) (distance "A" "G"))
-        , test "complete distance in small strands"
-            (\() -> Expect.equal (Just 2) (distance "AG" "CT"))
-        , test "small distance in small strands"
-            (\() -> Expect.equal (Just 1) (distance "AT" "CT"))
-        , test "small distance"
-            (\() -> Expect.equal (Just 1) (distance "GGACG" "GGTCG"))
-        , test "small distance in long strands"
-            (\() -> Expect.equal (Just 2) (distance "ACCAGGG" "ACTATGG"))
-        , test "non-unique character in first strand"
-            (\() -> Expect.equal (Just 1) (distance "AGA" "AGG"))
-        , test "non-unique character in second strand"
-            (\() -> Expect.equal (Just 1) (distance "AGG" "AGA"))
-        , test "large distance"
-            (\() -> Expect.equal (Just 4) (distance "GATACA" "GCATAA"))
-        , test "large distance in off-by-one strand"
-            (\() -> Expect.equal (Just 9) (distance "GGACGGATTCTG" "AGGACGGATTCT"))
-        , test "empty strands"
-            (\() -> Expect.equal (Just 0) (distance "" ""))
-        , test "disallow first strand longer"
-            (\() -> Expect.equal Nothing (distance "AATG" "AAA"))
-        , test "disallow second strand longer"
-            (\() -> Expect.equal Nothing (distance "ATA" "AGTG"))
+        [ test "identical strands" <|
+            \() -> Expect.equal (Just 0) (distance "A" "A")
+        , test "long identical strands" <|
+            \() -> Expect.equal (Just 0) (distance "GGACTGA" "GGACTGA")
+        , test "complete distance in single nucleotide strands" <|
+            \() -> Expect.equal (Just 1) (distance "A" "G")
+        , test "complete distance in small strands" <|
+            \() -> Expect.equal (Just 2) (distance "AG" "CT")
+        , test "small distance in small strands" <|
+            \() -> Expect.equal (Just 1) (distance "AT" "CT")
+        , test "small distance" <|
+            \() -> Expect.equal (Just 1) (distance "GGACG" "GGTCG")
+        , test "small distance in long strands" <|
+            \() -> Expect.equal (Just 2) (distance "ACCAGGG" "ACTATGG")
+        , test "non-unique character in first strand" <|
+            \() -> Expect.equal (Just 1) (distance "AGA" "AGG")
+        , test "non-unique character in second strand" <|
+            \() -> Expect.equal (Just 1) (distance "AGG" "AGA")
+        , test "large distance" <|
+            \() -> Expect.equal (Just 4) (distance "GATACA" "GCATAA")
+        , test "large distance in off-by-one strand" <|
+            \() -> Expect.equal (Just 9) (distance "GGACGGATTCTG" "AGGACGGATTCT")
+        , test "empty strands" <|
+            \() -> Expect.equal (Just 0) (distance "" "")
+        , test "disallow first strand longer" <|
+            \() -> Expect.equal Nothing (distance "AATG" "AAA")
+        , test "disallow second strand longer" <|
+            \() -> Expect.equal Nothing (distance "ATA" "AGTG")
         ]
 
 

--- a/exercises/hamming/elm-package.json
+++ b/exercises/hamming/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/hamming/runtests.bat
+++ b/exercises/hamming/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/hamming/runtests.sh
+++ b/exercises/hamming/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/hello-world/HelloWorldTests.elm
+++ b/exercises/hello-world/HelloWorldTests.elm
@@ -1,18 +1,33 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import HelloWorld exposing (helloWorld)
 
 
 tests : Test
 tests =
-    suite "Hello, World!"
-        [ test "Hello with no name" (assertEqual "Hello, World!" (helloWorld Nothing))
-        , test "Hello to a sample name" (assertEqual "Hello, Alice!" (helloWorld (Just "Alice")))
-        , test "Hello to another sample name" (assertEqual "Hello, Bob!" (helloWorld (Just "Bob")))
+    describe "Hello, World!"
+        [ test "Hello with no name"
+            (\() ->
+                Expect.equal "Hello, World!" (helloWorld Nothing)
+            )
+        , test "Hello to a sample name"
+            (\() ->
+                Expect.equal "Hello, Alice!" (helloWorld (Just "Alice"))
+            )
+        , test "Hello to another sample name"
+            (\() ->
+                Expect.equal "Hello, Bob!" (helloWorld (Just "Bob"))
+            )
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/hello-world/HelloWorldTests.elm
+++ b/exercises/hello-world/HelloWorldTests.elm
@@ -10,18 +10,15 @@ import HelloWorld exposing (helloWorld)
 tests : Test
 tests =
     describe "Hello, World!"
-        [ test "Hello with no name"
-            (\() ->
+        [ test "Hello with no name" <|
+            \() ->
                 Expect.equal "Hello, World!" (helloWorld Nothing)
-            )
-        , test "Hello to a sample name"
-            (\() ->
+        , test "Hello to a sample name" <|
+            \() ->
                 Expect.equal "Hello, Alice!" (helloWorld (Just "Alice"))
-            )
-        , test "Hello to another sample name"
-            (\() ->
+        , test "Hello to another sample name" <|
+            \() ->
                 Expect.equal "Hello, Bob!" (helloWorld (Just "Bob"))
-            )
         ]
 
 

--- a/exercises/hello-world/elm-package.json
+++ b/exercises/hello-world/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/hello-world/runtests.bat
+++ b/exercises/hello-world/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/hello-world/runtests.sh
+++ b/exercises/hello-world/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/largest-series-product/LargestSeriesProductTests.elm
+++ b/exercises/largest-series-product/LargestSeriesProductTests.elm
@@ -1,49 +1,55 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import LargestSeriesProduct exposing (largestProduct)
 
 
 tests : Test
 tests =
-    suite "largestProduct"
+    describe "largestProduct"
         [ test "can find the largest product of 2 with numbers in order"
-            (assertEqual (Just 72) (largestProduct 2 "0123456789"))
+            (\() -> Expect.equal (Just 72) (largestProduct 2 "0123456789"))
         , test "can find the largest product of 2"
-            (assertEqual (Just 48) (largestProduct 2 "576802143"))
+            (\() -> Expect.equal (Just 48) (largestProduct 2 "576802143"))
         , test "finds the largest product if span equals length"
-            (assertEqual (Just 18) (largestProduct 2 "29"))
+            (\() -> Expect.equal (Just 18) (largestProduct 2 "29"))
         , test "can find the largest product of 3 with numbers in order"
-            (assertEqual (Just 504) (largestProduct 3 "0123456789"))
+            (\() -> Expect.equal (Just 504) (largestProduct 3 "0123456789"))
         , test "can find the largest product of 3"
-            (assertEqual (Just 270) (largestProduct 3 "1027839564"))
+            (\() -> Expect.equal (Just 270) (largestProduct 3 "1027839564"))
         , test "can find the largest product of 5 with numbers in order"
-            (assertEqual (Just 15120) (largestProduct 5 "0123456789"))
+            (\() -> Expect.equal (Just 15120) (largestProduct 5 "0123456789"))
         , test "can get the largest product of a big number"
-            (assertEqual (Just 23520) (largestProduct 6 "73167176531330624919225119674426574742355349194934"))
+            (\() -> Expect.equal (Just 23520) (largestProduct 6 "73167176531330624919225119674426574742355349194934"))
         , test "can get the largest product of a big number II"
-            (assertEqual (Just 28350) (largestProduct 6 "52677741234314237566414902593461595376319419139427"))
+            (\() -> Expect.equal (Just 28350) (largestProduct 6 "52677741234314237566414902593461595376319419139427"))
         , test "can get the largest product of a big number (Project Euler)"
-            (assertEqual (Just 23514624000) (largestProduct 13 "7316717653133062491922511967442657474235534919493496983520312774506326239578318016984801869478851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096329522744304355766896648950445244523161731856403098711121722383113622298934233803081353362766142828064444866452387493035890729629049156044077239071381051585930796086670172427121883998797908792274921901699720888093776657273330010533678812202354218097512545405947522435258490771167055601360483958644670632441572215539753697817977846174064955149290862569321978468622482839722413756570560574902614079729686524145351004748216637048440319989000889524345065854122758866688116427171479924442928230863465674813919123162824586178664583591245665294765456828489128831426076900422421902267105562632111110937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450"))
+            (\() -> Expect.equal (Just 23514624000) (largestProduct 13 "7316717653133062491922511967442657474235534919493496983520312774506326239578318016984801869478851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096329522744304355766896648950445244523161731856403098711121722383113622298934233803081353362766142828064444866452387493035890729629049156044077239071381051585930796086670172427121883998797908792274921901699720888093776657273330010533678812202354218097512545405947522435258490771167055601360483958644670632441572215539753697817977846174064955149290862569321978468622482839722413756570560574902614079729686524145351004748216637048440319989000889524345065854122758866688116427171479924442928230863465674813919123162824586178664583591245665294765456828489128831426076900422421902267105562632111110937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450"))
         , test "reports zero if the only digits are zero"
-            (assertEqual (Just 0) (largestProduct 2 "0000"))
+            (\() -> Expect.equal (Just 0) (largestProduct 2 "0000"))
         , test "reports zero if all spans include zero"
-            (assertEqual (Just 0) (largestProduct 3 "99099"))
+            (\() -> Expect.equal (Just 0) (largestProduct 3 "99099"))
         , test "rejects span longer than string length"
-            (assertEqual Nothing (largestProduct 4 "123"))
+            (\() -> Expect.equal Nothing (largestProduct 4 "123"))
         , test "reports 1 for empty string and empty product (0 span)"
-            (assertEqual (Just 1) (largestProduct 0 ""))
+            (\() -> Expect.equal (Just 1) (largestProduct 0 ""))
         , test "reports 1 for nonempty string and empty product (0 span)"
-            (assertEqual (Just 1) (largestProduct 0 "123"))
+            (\() -> Expect.equal (Just 1) (largestProduct 0 "123"))
         , test "rejects empty string and nonzero span"
-            (assertEqual Nothing (largestProduct 1 ""))
+            (\() -> Expect.equal Nothing (largestProduct 1 ""))
         , test "rejects invalid character in digits"
-            (assertEqual Nothing (largestProduct 2 "1234a5"))
+            (\() -> Expect.equal Nothing (largestProduct 2 "1234a5"))
         , test "rejects negative span"
-            (assertEqual Nothing (largestProduct -1 "12345"))
+            (\() -> Expect.equal Nothing (largestProduct -1 "12345"))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/largest-series-product/LargestSeriesProductTests.elm
+++ b/exercises/largest-series-product/LargestSeriesProductTests.elm
@@ -10,40 +10,40 @@ import LargestSeriesProduct exposing (largestProduct)
 tests : Test
 tests =
     describe "largestProduct"
-        [ test "can find the largest product of 2 with numbers in order"
-            (\() -> Expect.equal (Just 72) (largestProduct 2 "0123456789"))
-        , test "can find the largest product of 2"
-            (\() -> Expect.equal (Just 48) (largestProduct 2 "576802143"))
-        , test "finds the largest product if span equals length"
-            (\() -> Expect.equal (Just 18) (largestProduct 2 "29"))
-        , test "can find the largest product of 3 with numbers in order"
-            (\() -> Expect.equal (Just 504) (largestProduct 3 "0123456789"))
-        , test "can find the largest product of 3"
-            (\() -> Expect.equal (Just 270) (largestProduct 3 "1027839564"))
-        , test "can find the largest product of 5 with numbers in order"
-            (\() -> Expect.equal (Just 15120) (largestProduct 5 "0123456789"))
-        , test "can get the largest product of a big number"
-            (\() -> Expect.equal (Just 23520) (largestProduct 6 "73167176531330624919225119674426574742355349194934"))
-        , test "can get the largest product of a big number II"
-            (\() -> Expect.equal (Just 28350) (largestProduct 6 "52677741234314237566414902593461595376319419139427"))
-        , test "can get the largest product of a big number (Project Euler)"
-            (\() -> Expect.equal (Just 23514624000) (largestProduct 13 "7316717653133062491922511967442657474235534919493496983520312774506326239578318016984801869478851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096329522744304355766896648950445244523161731856403098711121722383113622298934233803081353362766142828064444866452387493035890729629049156044077239071381051585930796086670172427121883998797908792274921901699720888093776657273330010533678812202354218097512545405947522435258490771167055601360483958644670632441572215539753697817977846174064955149290862569321978468622482839722413756570560574902614079729686524145351004748216637048440319989000889524345065854122758866688116427171479924442928230863465674813919123162824586178664583591245665294765456828489128831426076900422421902267105562632111110937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450"))
-        , test "reports zero if the only digits are zero"
-            (\() -> Expect.equal (Just 0) (largestProduct 2 "0000"))
-        , test "reports zero if all spans include zero"
-            (\() -> Expect.equal (Just 0) (largestProduct 3 "99099"))
-        , test "rejects span longer than string length"
-            (\() -> Expect.equal Nothing (largestProduct 4 "123"))
-        , test "reports 1 for empty string and empty product (0 span)"
-            (\() -> Expect.equal (Just 1) (largestProduct 0 ""))
-        , test "reports 1 for nonempty string and empty product (0 span)"
-            (\() -> Expect.equal (Just 1) (largestProduct 0 "123"))
-        , test "rejects empty string and nonzero span"
-            (\() -> Expect.equal Nothing (largestProduct 1 ""))
-        , test "rejects invalid character in digits"
-            (\() -> Expect.equal Nothing (largestProduct 2 "1234a5"))
-        , test "rejects negative span"
-            (\() -> Expect.equal Nothing (largestProduct -1 "12345"))
+        [ test "can find the largest product of 2 with numbers in order" <|
+            \() -> Expect.equal (Just 72) (largestProduct 2 "0123456789")
+        , test "can find the largest product of 2" <|
+            \() -> Expect.equal (Just 48) (largestProduct 2 "576802143")
+        , test "finds the largest product if span equals length" <|
+            \() -> Expect.equal (Just 18) (largestProduct 2 "29")
+        , test "can find the largest product of 3 with numbers in order" <|
+            \() -> Expect.equal (Just 504) (largestProduct 3 "0123456789")
+        , test "can find the largest product of 3" <|
+            \() -> Expect.equal (Just 270) (largestProduct 3 "1027839564")
+        , test "can find the largest product of 5 with numbers in order" <|
+            \() -> Expect.equal (Just 15120) (largestProduct 5 "0123456789")
+        , test "can get the largest product of a big number" <|
+            \() -> Expect.equal (Just 23520) (largestProduct 6 "73167176531330624919225119674426574742355349194934")
+        , test "can get the largest product of a big number II" <|
+            \() -> Expect.equal (Just 28350) (largestProduct 6 "52677741234314237566414902593461595376319419139427")
+        , test "can get the largest product of a big number (Project Euler)" <|
+            \() -> Expect.equal (Just 23514624000) (largestProduct 13 "7316717653133062491922511967442657474235534919493496983520312774506326239578318016984801869478851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096329522744304355766896648950445244523161731856403098711121722383113622298934233803081353362766142828064444866452387493035890729629049156044077239071381051585930796086670172427121883998797908792274921901699720888093776657273330010533678812202354218097512545405947522435258490771167055601360483958644670632441572215539753697817977846174064955149290862569321978468622482839722413756570560574902614079729686524145351004748216637048440319989000889524345065854122758866688116427171479924442928230863465674813919123162824586178664583591245665294765456828489128831426076900422421902267105562632111110937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450")
+        , test "reports zero if the only digits are zero" <|
+            \() -> Expect.equal (Just 0) (largestProduct 2 "0000")
+        , test "reports zero if all spans include zero" <|
+            \() -> Expect.equal (Just 0) (largestProduct 3 "99099")
+        , test "rejects span longer than string length" <|
+            \() -> Expect.equal Nothing (largestProduct 4 "123")
+        , test "reports 1 for empty string and empty product (0 span)" <|
+            \() -> Expect.equal (Just 1) (largestProduct 0 "")
+        , test "reports 1 for nonempty string and empty product (0 span)" <|
+            \() -> Expect.equal (Just 1) (largestProduct 0 "123")
+        , test "rejects empty string and nonzero span" <|
+            \() -> Expect.equal Nothing (largestProduct 1 "")
+        , test "rejects invalid character in digits" <|
+            \() -> Expect.equal Nothing (largestProduct 2 "1234a5")
+        , test "rejects negative span" <|
+            \() -> Expect.equal Nothing (largestProduct -1 "12345")
         ]
 
 

--- a/exercises/largest-series-product/elm-package.json
+++ b/exercises/largest-series-product/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/largest-series-product/runtests.bat
+++ b/exercises/largest-series-product/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/largest-series-product/runtests.sh
+++ b/exercises/largest-series-product/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/leap/LeapTests.elm
+++ b/exercises/leap/LeapTests.elm
@@ -10,13 +10,20 @@ import Leap
 tests : Test
 tests =
     describe "Leap"
-        [ test "leap year" (\() -> Expect.equal True (Leap.isLeapYear 1996))
-        , test "non-leap year" (\() -> Expect.equal False (Leap.isLeapYear 1997))
-        , test "non-leap even year" (\() -> Expect.equal False (Leap.isLeapYear 1998))
-        , test "century" (\() -> Expect.equal False (Leap.isLeapYear 1900))
-        , test "second century" (\() -> Expect.equal False (Leap.isLeapYear 1800))
-        , test "fourth century" (\() -> Expect.equal True (Leap.isLeapYear 2400))
-        , test "y2k" (\() -> Expect.equal True (Leap.isLeapYear 2000))
+        [ test "leap year" <|
+            \() -> Expect.equal True (Leap.isLeapYear 1996)
+        , test "non-leap year" <|
+            \() -> Expect.equal False (Leap.isLeapYear 1997)
+        , test "non-leap even year" <|
+            \() -> Expect.equal False (Leap.isLeapYear 1998)
+        , test "century" <|
+            \() -> Expect.equal False (Leap.isLeapYear 1900)
+        , test "second century" <|
+            \() -> Expect.equal False (Leap.isLeapYear 1800)
+        , test "fourth century" <|
+            \() -> Expect.equal True (Leap.isLeapYear 2400)
+        , test "y2k" <|
+            \() -> Expect.equal True (Leap.isLeapYear 2000)
         ]
 
 

--- a/exercises/leap/LeapTests.elm
+++ b/exercises/leap/LeapTests.elm
@@ -1,22 +1,28 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Leap
 
 
 tests : Test
 tests =
-    suite "Leap"
-        [ test "leap year" (assertEqual True (Leap.isLeapYear 1996))
-        , test "non-leap year" (assertEqual False (Leap.isLeapYear 1997))
-        , test "non-leap even year" (assertEqual False (Leap.isLeapYear 1998))
-        , test "century" (assertEqual False (Leap.isLeapYear 1900))
-        , test "second century" (assertEqual False (Leap.isLeapYear 1800))
-        , test "fourth century" (assertEqual True (Leap.isLeapYear 2400))
-        , test "y2k" (assertEqual True (Leap.isLeapYear 2000))
+    describe "Leap"
+        [ test "leap year" (\() -> Expect.equal True (Leap.isLeapYear 1996))
+        , test "non-leap year" (\() -> Expect.equal False (Leap.isLeapYear 1997))
+        , test "non-leap even year" (\() -> Expect.equal False (Leap.isLeapYear 1998))
+        , test "century" (\() -> Expect.equal False (Leap.isLeapYear 1900))
+        , test "second century" (\() -> Expect.equal False (Leap.isLeapYear 1800))
+        , test "fourth century" (\() -> Expect.equal True (Leap.isLeapYear 2400))
+        , test "y2k" (\() -> Expect.equal True (Leap.isLeapYear 2000))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/leap/elm-package.json
+++ b/exercises/leap/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/leap/runtests.bat
+++ b/exercises/leap/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/leap/runtests.sh
+++ b/exercises/leap/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/list-ops/ListOpsTests.elm
+++ b/exercises/list-ops/ListOpsTests.elm
@@ -11,60 +11,60 @@ tests : Test
 tests =
     describe "List Ops"
         [ describe "length"
-            [ test "empty list"
-                (\() -> Expect.equal 0 (ListOps.length []))
-            , test "non-empty list"
-                (\() -> Expect.equal 4 (ListOps.length [1..4]))
+            [ test "empty list" <|
+                \() -> Expect.equal 0 (ListOps.length [])
+            , test "non-empty list" <|
+                \() -> Expect.equal 4 (ListOps.length [1..4])
             ]
         , describe "reverse"
-            [ test "empty list"
-                (\() -> Expect.equal [] (ListOps.reverse []))
-            , test "non-empty list"
-                (\() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.reverse [1..4]))
+            [ test "empty list" <|
+                \() -> Expect.equal [] (ListOps.reverse [])
+            , test "non-empty list" <|
+                \() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.reverse [1..4])
             ]
         , describe "map"
-            [ test "empty list"
-                (\() -> Expect.equal [] (ListOps.map ((+) 1) []))
-            , test "non-empty list"
-                (\() -> Expect.equal [2..5] (ListOps.map ((+) 1) [1..4]))
+            [ test "empty list" <|
+                \() -> Expect.equal [] (ListOps.map ((+) 1) [])
+            , test "non-empty list" <|
+                \() -> Expect.equal [2..5] (ListOps.map ((+) 1) [1..4])
             ]
         , describe "filter"
-            [ test "empty list"
-                (\() -> Expect.equal [] (ListOps.filter (\_ -> True) []))
-            , test "non-empty list"
-                (\() -> Expect.equal [ 2, 4 ] (ListOps.filter (\x -> x % 2 == 0) [1..4]))
+            [ test "empty list" <|
+                \() -> Expect.equal [] (ListOps.filter (\_ -> True) [])
+            , test "non-empty list" <|
+                \() -> Expect.equal [ 2, 4 ] (ListOps.filter (\x -> x % 2 == 0) [1..4])
             ]
         , describe "foldl"
-            [ test "empty list"
-                (\() -> Expect.equal 0 (ListOps.foldl (+) 0 []))
-            , test "non-empty list"
-                (\() -> Expect.equal 10 (ListOps.foldl (+) 0 [1..4]))
-            , test "direction"
-                (\() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.foldl (::) [] [1..4]))
+            [ test "empty list" <|
+                \() -> Expect.equal 0 (ListOps.foldl (+) 0 [])
+            , test "non-empty list" <|
+                \() -> Expect.equal 10 (ListOps.foldl (+) 0 [1..4])
+            , test "direction" <|
+                \() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.foldl (::) [] [1..4])
             ]
         , describe "foldr"
-            [ test "empty list"
-                (\() -> Expect.equal 0 (ListOps.foldr (+) 0 []))
-            , test "non-empty list"
-                (\() -> Expect.equal 10 (ListOps.foldr (+) 0 [1..4]))
-            , test "direction"
-                (\() -> Expect.equal [1..4] (ListOps.foldr (::) [] [1..4]))
+            [ test "empty list" <|
+                \() -> Expect.equal 0 (ListOps.foldr (+) 0 [])
+            , test "non-empty list" <|
+                \() -> Expect.equal 10 (ListOps.foldr (+) 0 [1..4])
+            , test "direction" <|
+                \() -> Expect.equal [1..4] (ListOps.foldr (::) [] [1..4])
             ]
         , describe "append"
-            [ test "empty lists"
-                (\() -> Expect.equal [] (ListOps.append [] []))
-            , test "empty and non-empty lists"
-                (\() -> Expect.equal [1..4] (ListOps.append [] [1..4]))
-            , test "non-empty and empty lists"
-                (\() -> Expect.equal [1..4] (ListOps.append [1..4] []))
-            , test "non-empty lists"
-                (\() -> Expect.equal [1..8] (ListOps.append [1..4] [5..8]))
+            [ test "empty lists" <|
+                \() -> Expect.equal [] (ListOps.append [] [])
+            , test "empty and non-empty lists" <|
+                \() -> Expect.equal [1..4] (ListOps.append [] [1..4])
+            , test "non-empty and empty lists" <|
+                \() -> Expect.equal [1..4] (ListOps.append [1..4] [])
+            , test "non-empty lists" <|
+                \() -> Expect.equal [1..8] (ListOps.append [1..4] [5..8])
             ]
         , describe "concat"
-            [ test "empty list"
-                (\() -> Expect.equal [] (ListOps.concat []))
-            , test "list of lists"
-                (\() -> Expect.equal [1..10] (ListOps.concat [ [1..3], [], [4..7], [8..10] ]))
+            [ test "empty list" <|
+                \() -> Expect.equal [] (ListOps.concat [])
+            , test "list of lists" <|
+                \() -> Expect.equal [1..10] (ListOps.concat [ [1..3], [], [4..7], [8..10] ])
             ]
         ]
 

--- a/exercises/list-ops/ListOpsTests.elm
+++ b/exercises/list-ops/ListOpsTests.elm
@@ -1,55 +1,77 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import ListOps exposing (..)
 
 
 tests : Test
 tests =
-    suite "List Ops"
-        [ suite "length"
-            [ test "empty list" (assertEqual 0 (length []))
-            , test "non-empty list" (assertEqual 4 (length [1..4]))
-            ]
-        , suite "reverse"
-            [ test "empty list" (assertEqual [] (reverse []))
-            , test "non-empty list" (assertEqual [ 4, 3, 2, 1 ] (reverse [1..4]))
-            ]
-        , suite "map"
-            [ test "empty list" (assertEqual [] (map ((+) 1) []))
-            , test "non-empty list" (assertEqual [2..5] (map ((+) 1) [1..4]))
-            ]
-        , suite "filter"
-            [ test "empty list" (assertEqual [] (filter (\_ -> True) []))
+    describe "List Ops"
+        [ describe "length"
+            [ test "empty list"
+                (\() -> Expect.equal 0 (ListOps.length []))
             , test "non-empty list"
-                (assertEqual [ 2, 4 ] (filter (\x -> x % 2 == 0) [1..4]))
+                (\() -> Expect.equal 4 (ListOps.length [1..4]))
             ]
-        , suite "foldl"
-            [ test "empty list" (assertEqual 0 (foldl (+) 0 []))
-            , test "non-empty list" (assertEqual 10 (foldl (+) 0 [1..4]))
-            , test "direction" (assertEqual [4,3,2,1] (foldl (::) [] [1..4]))
+        , describe "reverse"
+            [ test "empty list"
+                (\() -> Expect.equal [] (ListOps.reverse []))
+            , test "non-empty list"
+                (\() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.reverse [1..4]))
             ]
-        , suite "foldr"
-            [ test "empty list" (assertEqual 0 (foldr (+) 0 []))
-            , test "non-empty list" (assertEqual 10 (foldr (+) 0 [1..4]))
-            , test "direction" (assertEqual [1..4] (foldr (::) [] [1..4]))
+        , describe "map"
+            [ test "empty list"
+                (\() -> Expect.equal [] (ListOps.map ((+) 1) []))
+            , test "non-empty list"
+                (\() -> Expect.equal [2..5] (ListOps.map ((+) 1) [1..4]))
             ]
-        , suite "append"
-            [ test "empty lists" (assertEqual [] (append [] []))
+        , describe "filter"
+            [ test "empty list"
+                (\() -> Expect.equal [] (ListOps.filter (\_ -> True) []))
+            , test "non-empty list"
+                (\() -> Expect.equal [ 2, 4 ] (ListOps.filter (\x -> x % 2 == 0) [1..4]))
+            ]
+        , describe "foldl"
+            [ test "empty list"
+                (\() -> Expect.equal 0 (ListOps.foldl (+) 0 []))
+            , test "non-empty list"
+                (\() -> Expect.equal 10 (ListOps.foldl (+) 0 [1..4]))
+            , test "direction"
+                (\() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.foldl (::) [] [1..4]))
+            ]
+        , describe "foldr"
+            [ test "empty list"
+                (\() -> Expect.equal 0 (ListOps.foldr (+) 0 []))
+            , test "non-empty list"
+                (\() -> Expect.equal 10 (ListOps.foldr (+) 0 [1..4]))
+            , test "direction"
+                (\() -> Expect.equal [1..4] (ListOps.foldr (::) [] [1..4]))
+            ]
+        , describe "append"
+            [ test "empty lists"
+                (\() -> Expect.equal [] (ListOps.append [] []))
             , test "empty and non-empty lists"
-                (assertEqual [1..4] (append [] [1..4]))
+                (\() -> Expect.equal [1..4] (ListOps.append [] [1..4]))
             , test "non-empty and empty lists"
-                (assertEqual [1..4] (append [1..4] []))
-            , test "non-empty lists" (assertEqual [1..8] (append [1..4] [5..8]))
+                (\() -> Expect.equal [1..4] (ListOps.append [1..4] []))
+            , test "non-empty lists"
+                (\() -> Expect.equal [1..8] (ListOps.append [1..4] [5..8]))
             ]
-        , suite "concat"
-            [ test "empty list" (assertEqual [] (concat []))
+        , describe "concat"
+            [ test "empty list"
+                (\() -> Expect.equal [] (ListOps.concat []))
             , test "list of lists"
-                (assertEqual [1..10] (concat [ [1..3], [], [4..7], [8..10] ]))
+                (\() -> Expect.equal [1..10] (ListOps.concat [ [1..3], [], [4..7], [8..10] ]))
             ]
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/list-ops/elm-package.json
+++ b/exercises/list-ops/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/list-ops/runtests.bat
+++ b/exercises/list-ops/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/list-ops/runtests.sh
+++ b/exercises/list-ops/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/nucleotide-count/NucleotideCountTests.elm
+++ b/exercises/nucleotide-count/NucleotideCountTests.elm
@@ -10,23 +10,20 @@ import NucleotideCount exposing (nucleotideCounts, version)
 tests : Test
 tests =
     describe "NucleotideCount"
-        [ test "the solution is for the correct version of the test"
-            (\() -> Expect.equal 2 version)
-        , test "empty dna strand has no nucleotides"
-            (\() ->
+        [ test "the solution is for the correct version of the test" <|
+            \() -> Expect.equal 2 version
+        , test "empty dna strand has no nucleotides" <|
+            \() ->
                 Expect.equal { a = 0, t = 0, c = 0, g = 0 }
                     (nucleotideCounts "")
-            )
-        , test "repetitive-sequence-has-only-guanosine"
-            (\() ->
+        , test "repetitive-sequence-has-only-guanosine" <|
+            \() ->
                 Expect.equal { a = 0, t = 0, c = 0, g = 8 }
                     (nucleotideCounts "GGGGGGGG")
-            )
-        , test "counts all nucleotides"
-            (\() ->
+        , test "counts all nucleotides" <|
+            \() ->
                 Expect.equal { a = 20, t = 21, c = 12, g = 17 }
                     (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")
-            )
         ]
 
 

--- a/exercises/nucleotide-count/NucleotideCountTests.elm
+++ b/exercises/nucleotide-count/NucleotideCountTests.elm
@@ -1,29 +1,38 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import NucleotideCount exposing (nucleotideCounts, version)
 
 
 tests : Test
 tests =
-    suite "NucleotideCount"
+    describe "NucleotideCount"
         [ test "the solution is for the correct version of the test"
-            (assertEqual 2 version)
+            (\() -> Expect.equal 2 version)
         , test "empty dna strand has no nucleotides"
-            (assertEqual { a = 0, t = 0, c = 0, g = 0 }
-                (nucleotideCounts "")
+            (\() ->
+                Expect.equal { a = 0, t = 0, c = 0, g = 0 }
+                    (nucleotideCounts "")
             )
         , test "repetitive-sequence-has-only-guanosine"
-            (assertEqual { a = 0, t = 0, c = 0, g = 8 }
-                (nucleotideCounts "GGGGGGGG")
+            (\() ->
+                Expect.equal { a = 0, t = 0, c = 0, g = 8 }
+                    (nucleotideCounts "GGGGGGGG")
             )
         , test "counts all nucleotides"
-            (assertEqual { a = 20, t = 21, c = 12, g = 17 }
-                (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")
+            (\() ->
+                Expect.equal { a = 20, t = 21, c = 12, g = 17 }
+                    (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")
             )
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/nucleotide-count/elm-package.json
+++ b/exercises/nucleotide-count/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/nucleotide-count/runtests.bat
+++ b/exercises/nucleotide-count/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/nucleotide-count/runtests.sh
+++ b/exercises/nucleotide-count/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/pangram/PangramTests.elm
+++ b/exercises/pangram/PangramTests.elm
@@ -1,51 +1,66 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Pangram exposing (isPangram)
 
 
 tests : Test
 tests =
-    suite "Pangram"
+    describe "Pangram"
         [ test "sentence empty"
-            (assertEqual False
-                (isPangram "")
+            (\() ->
+                Expect.equal False
+                    (isPangram "")
             )
         , test "pangram with only lower case"
-            (assertEqual True
-                (isPangram "the quick brown fox jumps over the lazy dog")
+            (\() ->
+                Expect.equal True
+                    (isPangram "the quick brown fox jumps over the lazy dog")
             )
         , test "missing character 'x'"
-            (assertEqual False
-                (isPangram "a quick movement of the enemy will jeopardize five gunboats")
+            (\() ->
+                Expect.equal False
+                    (isPangram "a quick movement of the enemy will jeopardize five gunboats")
             )
         , test "another missing character 'x'"
-            (assertEqual False
-                (isPangram "the quick brown fish jumps over the lazy dog")
+            (\() ->
+                Expect.equal False
+                    (isPangram "the quick brown fish jumps over the lazy dog")
             )
         , test "pangram with underscores"
-            (assertEqual True
-                (isPangram "the_quick_brown_fox_jumps_over_the_lazy_dog")
+            (\() ->
+                Expect.equal True
+                    (isPangram "the_quick_brown_fox_jumps_over_the_lazy_dog")
             )
         , test "pangram with numbers"
-            (assertEqual True
-                (isPangram "the 1 quick brown fox jumps over the 2 lazy dogs")
+            (\() ->
+                Expect.equal True
+                    (isPangram "the 1 quick brown fox jumps over the 2 lazy dogs")
             )
         , test "missing letters replaced by numbers"
-            (assertEqual False
-                (isPangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog")
+            (\() ->
+                Expect.equal False
+                    (isPangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog")
             )
         , test "pangram with mixed case and punctuation"
-            (assertEqual True
-                (isPangram "\"Five quacking Zephyrs jolt my wax bed.\"")
+            (\() ->
+                Expect.equal True
+                    (isPangram "\"Five quacking Zephyrs jolt my wax bed.\"")
             )
         , test "pangram with non ascii characters"
-            (assertEqual True
-                (isPangram "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.")
+            (\() ->
+                Expect.equal True
+                    (isPangram "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.")
             )
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/pangram/PangramTests.elm
+++ b/exercises/pangram/PangramTests.elm
@@ -10,51 +10,42 @@ import Pangram exposing (isPangram)
 tests : Test
 tests =
     describe "Pangram"
-        [ test "sentence empty"
-            (\() ->
+        [ test "sentence empty" <|
+            \() ->
                 Expect.equal False
                     (isPangram "")
-            )
-        , test "pangram with only lower case"
-            (\() ->
+        , test "pangram with only lower case" <|
+            \() ->
                 Expect.equal True
                     (isPangram "the quick brown fox jumps over the lazy dog")
-            )
-        , test "missing character 'x'"
-            (\() ->
+        , test "missing character 'x'" <|
+            \() ->
                 Expect.equal False
                     (isPangram "a quick movement of the enemy will jeopardize five gunboats")
-            )
-        , test "another missing character 'x'"
-            (\() ->
+        , test "another missing character 'x'" <|
+            \() ->
                 Expect.equal False
                     (isPangram "the quick brown fish jumps over the lazy dog")
-            )
-        , test "pangram with underscores"
-            (\() ->
+        , test "pangram with underscores" <|
+            \() ->
                 Expect.equal True
                     (isPangram "the_quick_brown_fox_jumps_over_the_lazy_dog")
-            )
-        , test "pangram with numbers"
-            (\() ->
+        , test "pangram with numbers" <|
+            \() ->
                 Expect.equal True
                     (isPangram "the 1 quick brown fox jumps over the 2 lazy dogs")
-            )
-        , test "missing letters replaced by numbers"
-            (\() ->
+        , test "missing letters replaced by numbers" <|
+            \() ->
                 Expect.equal False
                     (isPangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog")
-            )
-        , test "pangram with mixed case and punctuation"
-            (\() ->
+        , test "pangram with mixed case and punctuation" <|
+            \() ->
                 Expect.equal True
                     (isPangram "\"Five quacking Zephyrs jolt my wax bed.\"")
-            )
-        , test "pangram with non ascii characters"
-            (\() ->
+        , test "pangram with non ascii characters" <|
+            \() ->
                 Expect.equal True
                     (isPangram "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.")
-            )
         ]
 
 

--- a/exercises/pangram/elm-package.json
+++ b/exercises/pangram/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/pangram/runtests.bat
+++ b/exercises/pangram/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/pangram/runtests.sh
+++ b/exercises/pangram/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/phone-number/PhoneNumberTests.elm
+++ b/exercises/phone-number/PhoneNumberTests.elm
@@ -1,39 +1,45 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import PhoneNumber exposing (getNumber, prettyPrint)
 
 
 tests : Test
 tests =
-    suite "PhoneNumber"
+    describe "PhoneNumber"
         [ test "cleans number"
-            (assertEqual (Just "1234567890") (getNumber "(123) 456-7890"))
+            (\() -> Expect.equal (Just "1234567890") (getNumber "(123) 456-7890"))
         , test "cleans number with dots"
-            (assertEqual (Just "1234567890") (getNumber "123.456.7890"))
+            (\() -> Expect.equal (Just "1234567890") (getNumber "123.456.7890"))
         , test "valid when 11 digits and first is 1"
-            (assertEqual (Just "1234567890") (getNumber "11234567890"))
+            (\() -> Expect.equal (Just "1234567890") (getNumber "11234567890"))
         , test "invalid when 11 digits"
-            (assertEqual Nothing (getNumber "21234567890"))
+            (\() -> Expect.equal Nothing (getNumber "21234567890"))
         , test "invalid when 9 digits"
-            (assertEqual Nothing (getNumber "123456789"))
+            (\() -> Expect.equal Nothing (getNumber "123456789"))
         , test "invalid when 12 digits"
-            (assertEqual Nothing (getNumber "123456789012"))
+            (\() -> Expect.equal Nothing (getNumber "123456789012"))
         , test "invalid when empty"
-            (assertEqual Nothing (getNumber ""))
+            (\() -> Expect.equal Nothing (getNumber ""))
         , test "invalid when no digits present"
-            (assertEqual Nothing (getNumber " (-) "))
+            (\() -> Expect.equal Nothing (getNumber " (-) "))
         , test "valid with leading characters"
-            (assertEqual (Just "1234567890") (getNumber "my number is 123 456 7890"))
+            (\() -> Expect.equal (Just "1234567890") (getNumber "my number is 123 456 7890"))
         , test "valid with trailing characters"
-            (assertEqual (Just "1234567890") (getNumber "123 456 7890 - bob"))
+            (\() -> Expect.equal (Just "1234567890") (getNumber "123 456 7890 - bob"))
         , test "pretty print"
-            (assertEqual (Just "(123) 456-7890") (prettyPrint "1234567890"))
+            (\() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "1234567890"))
         , test "pretty print with full us phone number"
-            (assertEqual (Just "(123) 456-7890") (prettyPrint "11234567890"))
+            (\() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "11234567890"))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/phone-number/PhoneNumberTests.elm
+++ b/exercises/phone-number/PhoneNumberTests.elm
@@ -10,30 +10,30 @@ import PhoneNumber exposing (getNumber, prettyPrint)
 tests : Test
 tests =
     describe "PhoneNumber"
-        [ test "cleans number"
-            (\() -> Expect.equal (Just "1234567890") (getNumber "(123) 456-7890"))
-        , test "cleans number with dots"
-            (\() -> Expect.equal (Just "1234567890") (getNumber "123.456.7890"))
-        , test "valid when 11 digits and first is 1"
-            (\() -> Expect.equal (Just "1234567890") (getNumber "11234567890"))
-        , test "invalid when 11 digits"
-            (\() -> Expect.equal Nothing (getNumber "21234567890"))
-        , test "invalid when 9 digits"
-            (\() -> Expect.equal Nothing (getNumber "123456789"))
-        , test "invalid when 12 digits"
-            (\() -> Expect.equal Nothing (getNumber "123456789012"))
-        , test "invalid when empty"
-            (\() -> Expect.equal Nothing (getNumber ""))
-        , test "invalid when no digits present"
-            (\() -> Expect.equal Nothing (getNumber " (-) "))
-        , test "valid with leading characters"
-            (\() -> Expect.equal (Just "1234567890") (getNumber "my number is 123 456 7890"))
-        , test "valid with trailing characters"
-            (\() -> Expect.equal (Just "1234567890") (getNumber "123 456 7890 - bob"))
-        , test "pretty print"
-            (\() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "1234567890"))
-        , test "pretty print with full us phone number"
-            (\() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "11234567890"))
+        [ test "cleans number" <|
+            \() -> Expect.equal (Just "1234567890") (getNumber "(123) 456-7890")
+        , test "cleans number with dots" <|
+            \() -> Expect.equal (Just "1234567890") (getNumber "123.456.7890")
+        , test "valid when 11 digits and first is 1" <|
+            \() -> Expect.equal (Just "1234567890") (getNumber "11234567890")
+        , test "invalid when 11 digits" <|
+            \() -> Expect.equal Nothing (getNumber "21234567890")
+        , test "invalid when 9 digits" <|
+            \() -> Expect.equal Nothing (getNumber "123456789")
+        , test "invalid when 12 digits" <|
+            \() -> Expect.equal Nothing (getNumber "123456789012")
+        , test "invalid when empty" <|
+            \() -> Expect.equal Nothing (getNumber "")
+        , test "invalid when no digits present" <|
+            \() -> Expect.equal Nothing (getNumber " (-) ")
+        , test "valid with leading characters" <|
+            \() -> Expect.equal (Just "1234567890") (getNumber "my number is 123 456 7890")
+        , test "valid with trailing characters" <|
+            \() -> Expect.equal (Just "1234567890") (getNumber "123 456 7890 - bob")
+        , test "pretty print" <|
+            \() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "1234567890")
+        , test "pretty print with full us phone number" <|
+            \() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "11234567890")
         ]
 
 

--- a/exercises/phone-number/elm-package.json
+++ b/exercises/phone-number/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/phone-number/runtests.bat
+++ b/exercises/phone-number/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/phone-number/runtests.sh
+++ b/exercises/phone-number/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/raindrops/RaindropsTests.elm
+++ b/exercises/raindrops/RaindropsTests.elm
@@ -10,21 +10,36 @@ import Raindrops exposing (raindrops)
 tests : Test
 tests =
     describe "Raindrops"
-        [ test "1" (\() -> Expect.equal "1" (raindrops 1))
-        , test "3" (\() -> Expect.equal "Pling" (raindrops 3))
-        , test "5" (\() -> Expect.equal "Plang" (raindrops 5))
-        , test "7" (\() -> Expect.equal "Plong" (raindrops 7))
-        , test "6" (\() -> Expect.equal "Pling" (raindrops 6))
-        , test "9" (\() -> Expect.equal "Pling" (raindrops 9))
-        , test "10" (\() -> Expect.equal "Plang" (raindrops 10))
-        , test "14" (\() -> Expect.equal "Plong" (raindrops 14))
-        , test "15" (\() -> Expect.equal "PlingPlang" (raindrops 15))
-        , test "21" (\() -> Expect.equal "PlingPlong" (raindrops 21))
-        , test "25" (\() -> Expect.equal "Plang" (raindrops 25))
-        , test "35" (\() -> Expect.equal "PlangPlong" (raindrops 35))
-        , test "49" (\() -> Expect.equal "Plong" (raindrops 49))
-        , test "52" (\() -> Expect.equal "52" (raindrops 52))
-        , test "105" (\() -> Expect.equal "PlingPlangPlong" (raindrops 105))
+        [ test "1" <|
+            \() -> Expect.equal "1" (raindrops 1)
+        , test "3" <|
+            \() -> Expect.equal "Pling" (raindrops 3)
+        , test "5" <|
+            \() -> Expect.equal "Plang" (raindrops 5)
+        , test "7" <|
+            \() -> Expect.equal "Plong" (raindrops 7)
+        , test "6" <|
+            \() -> Expect.equal "Pling" (raindrops 6)
+        , test "9" <|
+            \() -> Expect.equal "Pling" (raindrops 9)
+        , test "10" <|
+            \() -> Expect.equal "Plang" (raindrops 10)
+        , test "14" <|
+            \() -> Expect.equal "Plong" (raindrops 14)
+        , test "15" <|
+            \() -> Expect.equal "PlingPlang" (raindrops 15)
+        , test "21" <|
+            \() -> Expect.equal "PlingPlong" (raindrops 21)
+        , test "25" <|
+            \() -> Expect.equal "Plang" (raindrops 25)
+        , test "35" <|
+            \() -> Expect.equal "PlangPlong" (raindrops 35)
+        , test "49" <|
+            \() -> Expect.equal "Plong" (raindrops 49)
+        , test "52" <|
+            \() -> Expect.equal "52" (raindrops 52)
+        , test "105" <|
+            \() -> Expect.equal "PlingPlangPlong" (raindrops 105)
         ]
 
 

--- a/exercises/raindrops/RaindropsTests.elm
+++ b/exercises/raindrops/RaindropsTests.elm
@@ -1,30 +1,36 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Raindrops exposing (raindrops)
 
 
 tests : Test
 tests =
-    suite "Raindrops"
-        [ test "1" (assertEqual "1" (raindrops 1))
-        , test "3" (assertEqual "Pling" (raindrops 3))
-        , test "5" (assertEqual "Plang" (raindrops 5))
-        , test "7" (assertEqual "Plong" (raindrops 7))
-        , test "6" (assertEqual "Pling" (raindrops 6))
-        , test "9" (assertEqual "Pling" (raindrops 9))
-        , test "10" (assertEqual "Plang" (raindrops 10))
-        , test "14" (assertEqual "Plong" (raindrops 14))
-        , test "15" (assertEqual "PlingPlang" (raindrops 15))
-        , test "21" (assertEqual "PlingPlong" (raindrops 21))
-        , test "25" (assertEqual "Plang" (raindrops 25))
-        , test "35" (assertEqual "PlangPlong" (raindrops 35))
-        , test "49" (assertEqual "Plong" (raindrops 49))
-        , test "52" (assertEqual "52" (raindrops 52))
-        , test "105" (assertEqual "PlingPlangPlong" (raindrops 105))
+    describe "Raindrops"
+        [ test "1" (\() -> Expect.equal "1" (raindrops 1))
+        , test "3" (\() -> Expect.equal "Pling" (raindrops 3))
+        , test "5" (\() -> Expect.equal "Plang" (raindrops 5))
+        , test "7" (\() -> Expect.equal "Plong" (raindrops 7))
+        , test "6" (\() -> Expect.equal "Pling" (raindrops 6))
+        , test "9" (\() -> Expect.equal "Pling" (raindrops 9))
+        , test "10" (\() -> Expect.equal "Plang" (raindrops 10))
+        , test "14" (\() -> Expect.equal "Plong" (raindrops 14))
+        , test "15" (\() -> Expect.equal "PlingPlang" (raindrops 15))
+        , test "21" (\() -> Expect.equal "PlingPlong" (raindrops 21))
+        , test "25" (\() -> Expect.equal "Plang" (raindrops 25))
+        , test "35" (\() -> Expect.equal "PlangPlong" (raindrops 35))
+        , test "49" (\() -> Expect.equal "Plong" (raindrops 49))
+        , test "52" (\() -> Expect.equal "52" (raindrops 52))
+        , test "105" (\() -> Expect.equal "PlingPlangPlong" (raindrops 105))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/raindrops/elm-package.json
+++ b/exercises/raindrops/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/raindrops/runtests.bat
+++ b/exercises/raindrops/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/raindrops/runtests.sh
+++ b/exercises/raindrops/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/rna-transcription/RNATranscriptionTests.elm
+++ b/exercises/rna-transcription/RNATranscriptionTests.elm
@@ -1,29 +1,35 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import RNATranscription exposing (toRNA)
 
 
 tests : Test
 tests =
-    suite "RNATranscription"
+    describe "RNATranscription"
         [ test "complement of cytosine is guanine"
-            (assertEqual (Ok "G") (toRNA "C"))
+            (\() -> Expect.equal (Ok "G") (toRNA "C"))
         , test "complement of guanine is cytosine"
-            (assertEqual (Ok "C") (toRNA "G"))
+            (\() -> Expect.equal (Ok "C") (toRNA "G"))
         , test "complement of thymine is adenine"
-            (assertEqual (Ok "A") (toRNA "T"))
+            (\() -> Expect.equal (Ok "A") (toRNA "T"))
         , test "complement of adenine is uracil"
-            (assertEqual (Ok "U") (toRNA "A"))
+            (\() -> Expect.equal (Ok "U") (toRNA "A"))
         , test "complement"
-            (assertEqual (Ok "UGCACCAGAAUU") (toRNA "ACGTGGTCTTAA"))
+            (\() -> Expect.equal (Ok "UGCACCAGAAUU") (toRNA "ACGTGGTCTTAA"))
         , test "correctly handles completely invalid input"
-            (assertEqual (Err 'X') (toRNA "XXX"))
+            (\() -> Expect.equal (Err 'X') (toRNA "XXX"))
         , test "correctly handles partially invalid input"
-            (assertEqual (Err 'U') (toRNA "UGAAXXXGACAUG"))
+            (\() -> Expect.equal (Err 'U') (toRNA "UGAAXXXGACAUG"))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/rna-transcription/RNATranscriptionTests.elm
+++ b/exercises/rna-transcription/RNATranscriptionTests.elm
@@ -10,20 +10,20 @@ import RNATranscription exposing (toRNA)
 tests : Test
 tests =
     describe "RNATranscription"
-        [ test "complement of cytosine is guanine"
-            (\() -> Expect.equal (Ok "G") (toRNA "C"))
-        , test "complement of guanine is cytosine"
-            (\() -> Expect.equal (Ok "C") (toRNA "G"))
-        , test "complement of thymine is adenine"
-            (\() -> Expect.equal (Ok "A") (toRNA "T"))
-        , test "complement of adenine is uracil"
-            (\() -> Expect.equal (Ok "U") (toRNA "A"))
-        , test "complement"
-            (\() -> Expect.equal (Ok "UGCACCAGAAUU") (toRNA "ACGTGGTCTTAA"))
-        , test "correctly handles completely invalid input"
-            (\() -> Expect.equal (Err 'X') (toRNA "XXX"))
-        , test "correctly handles partially invalid input"
-            (\() -> Expect.equal (Err 'U') (toRNA "UGAAXXXGACAUG"))
+        [ test "complement of cytosine is guanine" <|
+            \() -> Expect.equal (Ok "G") (toRNA "C")
+        , test "complement of guanine is cytosine" <|
+            \() -> Expect.equal (Ok "C") (toRNA "G")
+        , test "complement of thymine is adenine" <|
+            \() -> Expect.equal (Ok "A") (toRNA "T")
+        , test "complement of adenine is uracil" <|
+            \() -> Expect.equal (Ok "U") (toRNA "A")
+        , test "complement" <|
+            \() -> Expect.equal (Ok "UGCACCAGAAUU") (toRNA "ACGTGGTCTTAA")
+        , test "correctly handles completely invalid input" <|
+            \() -> Expect.equal (Err 'X') (toRNA "XXX")
+        , test "correctly handles partially invalid input" <|
+            \() -> Expect.equal (Err 'U') (toRNA "UGAAXXXGACAUG")
         ]
 
 

--- a/exercises/rna-transcription/elm-package.json
+++ b/exercises/rna-transcription/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/rna-transcription/runtests.bat
+++ b/exercises/rna-transcription/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/rna-transcription/runtests.sh
+++ b/exercises/rna-transcription/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/robot-simulator/RobotSimulatorTests.elm
+++ b/exercises/robot-simulator/RobotSimulatorTests.elm
@@ -15,8 +15,10 @@ tests =
                 robot =
                     defaultRobot
              in
-                [ test "coordinates" (\() -> Expect.equal { x = 0, y = 0 } robot.coordinates)
-                , test "bearing" (\() -> Expect.equal North robot.bearing)
+                [ test "coordinates" <|
+                    \() -> Expect.equal { x = 0, y = 0 } robot.coordinates
+                , test "bearing" <|
+                    \() -> Expect.equal North robot.bearing
                 ]
             )
         , describe "setup"
@@ -24,8 +26,10 @@ tests =
                 robot =
                     Robot South { x = -1, y = 1 }
              in
-                [ test "coordinates" (\() -> Expect.equal { x = -1, y = 1 } robot.coordinates)
-                , test "bearing" (\() -> Expect.equal South robot.bearing)
+                [ test "coordinates" <|
+                    \() -> Expect.equal { x = -1, y = 1 } robot.coordinates
+                , test "bearing" <|
+                    \() -> Expect.equal South robot.bearing
                 ]
             )
         , describe "turn right"
@@ -49,8 +53,10 @@ tests =
                     Robot North { x = 0, y = 0 }
                         |> advance
              in
-                [ test "coordinates" (\() -> Expect.equal { x = 0, y = 1 } robot.coordinates)
-                , test "bearing" (\() -> Expect.equal North robot.bearing)
+                [ test "coordinates" <|
+                    \() -> Expect.equal { x = 0, y = 1 } robot.coordinates
+                , test "bearing" <|
+                    \() -> Expect.equal North robot.bearing
                 ]
             )
         , describe "advance positive east"
@@ -59,8 +65,10 @@ tests =
                     Robot East { x = 0, y = 0 }
                         |> advance
              in
-                [ test "coordinates" (\() -> Expect.equal { x = 1, y = 0 } robot.coordinates)
-                , test "bearing" (\() -> Expect.equal East robot.bearing)
+                [ test "coordinates" <|
+                    \() -> Expect.equal { x = 1, y = 0 } robot.coordinates
+                , test "bearing" <|
+                    \() -> Expect.equal East robot.bearing
                 ]
             )
         , describe "advance negative south"
@@ -69,8 +77,10 @@ tests =
                     Robot South { x = 0, y = 0 }
                         |> advance
              in
-                [ test "coordinates" (\() -> Expect.equal { x = 0, y = -1 } robot.coordinates)
-                , test "bearing" (\() -> Expect.equal South robot.bearing)
+                [ test "coordinates" <|
+                    \() -> Expect.equal { x = 0, y = -1 } robot.coordinates
+                , test "bearing" <|
+                    \() -> Expect.equal South robot.bearing
                 ]
             )
         , describe "advance positive west"
@@ -79,8 +89,10 @@ tests =
                     Robot West { x = 0, y = 0 }
                         |> advance
              in
-                [ test "coordinates" (\() -> Expect.equal { x = -1, y = 0 } robot.coordinates)
-                , test "bearing" (\() -> Expect.equal West robot.bearing)
+                [ test "coordinates" <|
+                    \() -> Expect.equal { x = -1, y = 0 } robot.coordinates
+                , test "bearing" <|
+                    \() -> Expect.equal West robot.bearing
                 ]
             )
         , describe "simulate prog 1"
@@ -89,8 +101,10 @@ tests =
                     Robot North { x = 0, y = 0 }
                         |> simulate "LAAARALA"
              in
-                [ test "coordinates" (\() -> Expect.equal { x = -4, y = 1 } robot.coordinates)
-                , test "bearing" (\() -> Expect.equal West robot.bearing)
+                [ test "coordinates" <|
+                    \() -> Expect.equal { x = -4, y = 1 } robot.coordinates
+                , test "bearing" <|
+                    \() -> Expect.equal West robot.bearing
                 ]
             )
         , describe "simulate prog 2"
@@ -99,8 +113,10 @@ tests =
                     Robot East { x = 2, y = -7 }
                         |> simulate "RRAAAAALA"
              in
-                [ test "coordinates" (\() -> Expect.equal { x = -3, y = -8 } robot.coordinates)
-                , test "bearing" (\() -> Expect.equal South robot.bearing)
+                [ test "coordinates" <|
+                    \() -> Expect.equal { x = -3, y = -8 } robot.coordinates
+                , test "bearing" <|
+                    \() -> Expect.equal South robot.bearing
                 ]
             )
         , describe "simulate prog 3"
@@ -109,8 +125,10 @@ tests =
                     Robot South { x = 8, y = 4 }
                         |> simulate "LAAARRRALLLL"
              in
-                [ test "coordinates" (\() -> Expect.equal { x = 11, y = 5 } robot.coordinates)
-                , test "bearing" (\() -> Expect.equal North robot.bearing)
+                [ test "coordinates" <|
+                    \() -> Expect.equal { x = 11, y = 5 } robot.coordinates
+                , test "bearing" <|
+                    \() -> Expect.equal North robot.bearing
                 ]
             )
         ]

--- a/exercises/robot-simulator/elm-package.json
+++ b/exercises/robot-simulator/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/robot-simulator/runtests.bat
+++ b/exercises/robot-simulator/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/robot-simulator/runtests.sh
+++ b/exercises/robot-simulator/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/roman-numerals/RomanNumerals.example
+++ b/exercises/roman-numerals/RomanNumerals.example
@@ -6,41 +6,45 @@ import Maybe
 
 toRoman : Int -> String
 toRoman number =
-  if number == 0 then
-    ""
-  else
-    let
-      part = largestFactor number
-      letter =
-        numerals
-        |> Dict.get part 
-        |> Maybe.withDefault ""
-    in
-      letter ++ (toRoman (number - part))
+    if number == 0 then
+        ""
+    else
+        let
+            part =
+                largestFactor number
+
+            letter =
+                numerals
+                    |> Dict.get part
+                    |> Maybe.withDefault ""
+        in
+            letter ++ (toRoman (number - part))
+
 
 largestFactor : Int -> Int
 largestFactor number =
-  numerals
-  |> Dict.keys
-  |> List.filter (\p -> p <= number)
-  |> List.reverse
-  |> List.head
-  |> Maybe.withDefault 0
+    numerals
+        |> Dict.keys
+        |> List.filter (\p -> p <= number)
+        |> List.reverse
+        |> List.head
+        |> Maybe.withDefault 0
 
 
 numerals : Dict.Dict Int String
-numerals = Dict.fromList [
-    (1000, "M"),
-    ( 900, "CM"),
-    ( 500, "D"),
-    ( 400, "CD"),
-    ( 100, "C"),
-    (  90, "XC"),
-    (  50, "L"),
-    (  40, "XL"),
-    (  10, "X"),
-    (   9, "IX"),
-    (   5, "V"),
-    (   4, "IV"),
-    (   1, "I")
-  ]
+numerals =
+    Dict.fromList
+        [ ( 1000, "M" )
+        , ( 900, "CM" )
+        , ( 500, "D" )
+        , ( 400, "CD" )
+        , ( 100, "C" )
+        , ( 90, "XC" )
+        , ( 50, "L" )
+        , ( 40, "XL" )
+        , ( 10, "X" )
+        , ( 9, "IX" )
+        , ( 5, "V" )
+        , ( 4, "IV" )
+        , ( 1, "I" )
+        ]

--- a/exercises/roman-numerals/RomanNumeralsTests.elm
+++ b/exercises/roman-numerals/RomanNumeralsTests.elm
@@ -10,96 +10,78 @@ import RomanNumerals exposing (toRoman)
 tests : Test
 tests =
     describe "Roman Numerals"
-        [ test "1"
-            (\() ->
+        [ test "1" <|
+            \() ->
                 Expect.equal ("I")
                     (toRoman 1)
-            )
-        , test "2"
-            (\() ->
+        , test "2" <|
+            \() ->
                 Expect.equal ("II")
                     (toRoman 2)
-            )
-        , test "3"
-            (\() ->
+        , test "3" <|
+            \() ->
                 Expect.equal ("III")
                     (toRoman 3)
-            )
-        , test "4"
-            (\() ->
+        , test "4" <|
+            \() ->
                 Expect.equal ("IV")
                     (toRoman 4)
-            )
-        , test "5"
-            (\() ->
+        , test "5" <|
+            \() ->
                 Expect.equal ("V")
                     (toRoman 5)
-            )
-        , test "6"
-            (\() ->
+        , test "6" <|
+            \() ->
                 Expect.equal ("VI")
                     (toRoman 6)
-            )
-        , test "9"
-            (\() ->
+        , test "9" <|
+            \() ->
                 Expect.equal ("IX")
                     (toRoman 9)
-            )
-        , test "27"
-            (\() ->
+        , test "27" <|
+            \() ->
                 Expect.equal ("XXVII")
                     (toRoman 27)
-            )
-        , test "48"
-            (\() ->
+        , test "48" <|
+            \() ->
                 Expect.equal ("XLVIII")
                     (toRoman 48)
-            )
-        , test "59"
-            (\() ->
+        , test "59" <|
+            \() ->
                 Expect.equal ("LIX")
                     (toRoman 59)
-            )
-        , test "93"
-            (\() ->
+        , test "93" <|
+            \() ->
                 Expect.equal ("XCIII")
                     (toRoman 93)
-            )
-        , test "141"
-            (\() ->
+        , test "141" <|
+            \() ->
                 Expect.equal ("CXLI")
                     (toRoman 141)
-            )
-        , test "163"
-            (\() ->
+        , test "163" <|
+            \() ->
                 Expect.equal ("CLXIII")
                     (toRoman 163)
-            )
-        , test "402"
-            (\() ->
+        , test "402" <|
+            \() ->
                 Expect.equal ("CDII")
                     (toRoman 402)
-            )
-        , test "575"
-            (\() ->
+        , test "575" <|
+            \() ->
                 Expect.equal ("DLXXV")
                     (toRoman 575)
-            )
-        , test "911"
-            (\() ->
+        , test "911" <|
+            \() ->
                 Expect.equal ("CMXI")
                     (toRoman 911)
-            )
-        , test "1024"
-            (\() ->
+        , test "1024" <|
+            \() ->
                 Expect.equal ("MXXIV")
                     (toRoman 1024)
-            )
-        , test "3000"
-            (\() ->
+        , test "3000" <|
+            \() ->
                 Expect.equal ("MMM")
                     (toRoman 3000)
-            )
         ]
 
 

--- a/exercises/roman-numerals/RomanNumeralsTests.elm
+++ b/exercises/roman-numerals/RomanNumeralsTests.elm
@@ -1,86 +1,111 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import RomanNumerals exposing (toRoman)
 
 
 tests : Test
 tests =
-    suite "Roman Numerals"
+    describe "Roman Numerals"
         [ test "1"
-            (assertEqual ("I")
-                (toRoman 1)
+            (\() ->
+                Expect.equal ("I")
+                    (toRoman 1)
             )
         , test "2"
-            (assertEqual ("II")
-                (toRoman 2)
+            (\() ->
+                Expect.equal ("II")
+                    (toRoman 2)
             )
         , test "3"
-            (assertEqual ("III")
-                (toRoman 3)
+            (\() ->
+                Expect.equal ("III")
+                    (toRoman 3)
             )
         , test "4"
-            (assertEqual ("IV")
-                (toRoman 4)
+            (\() ->
+                Expect.equal ("IV")
+                    (toRoman 4)
             )
         , test "5"
-            (assertEqual ("V")
-                (toRoman 5)
+            (\() ->
+                Expect.equal ("V")
+                    (toRoman 5)
             )
         , test "6"
-            (assertEqual ("VI")
-                (toRoman 6)
+            (\() ->
+                Expect.equal ("VI")
+                    (toRoman 6)
             )
         , test "9"
-            (assertEqual ("IX")
-                (toRoman 9)
+            (\() ->
+                Expect.equal ("IX")
+                    (toRoman 9)
             )
         , test "27"
-            (assertEqual ("XXVII")
-                (toRoman 27)
+            (\() ->
+                Expect.equal ("XXVII")
+                    (toRoman 27)
             )
         , test "48"
-            (assertEqual ("XLVIII")
-                (toRoman 48)
+            (\() ->
+                Expect.equal ("XLVIII")
+                    (toRoman 48)
             )
         , test "59"
-            (assertEqual ("LIX")
-                (toRoman 59)
+            (\() ->
+                Expect.equal ("LIX")
+                    (toRoman 59)
             )
         , test "93"
-            (assertEqual ("XCIII")
-                (toRoman 93)
+            (\() ->
+                Expect.equal ("XCIII")
+                    (toRoman 93)
             )
         , test "141"
-            (assertEqual ("CXLI")
-                (toRoman 141)
+            (\() ->
+                Expect.equal ("CXLI")
+                    (toRoman 141)
             )
         , test "163"
-            (assertEqual ("CLXIII")
-                (toRoman 163)
+            (\() ->
+                Expect.equal ("CLXIII")
+                    (toRoman 163)
             )
         , test "402"
-            (assertEqual ("CDII")
-                (toRoman 402)
+            (\() ->
+                Expect.equal ("CDII")
+                    (toRoman 402)
             )
         , test "575"
-            (assertEqual ("DLXXV")
-                (toRoman 575)
+            (\() ->
+                Expect.equal ("DLXXV")
+                    (toRoman 575)
             )
         , test "911"
-            (assertEqual ("CMXI")
-                (toRoman 911)
+            (\() ->
+                Expect.equal ("CMXI")
+                    (toRoman 911)
             )
         , test "1024"
-            (assertEqual ("MXXIV")
-                (toRoman 1024)
+            (\() ->
+                Expect.equal ("MXXIV")
+                    (toRoman 1024)
             )
         , test "3000"
-            (assertEqual ("MMM")
-                (toRoman 3000)
+            (\() ->
+                Expect.equal ("MMM")
+                    (toRoman 3000)
             )
         ]
 
+
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/roman-numerals/elm-package.json
+++ b/exercises/roman-numerals/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/roman-numerals/runtests.bat
+++ b/exercises/roman-numerals/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/roman-numerals/runtests.sh
+++ b/exercises/roman-numerals/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/run-length-encoding/RunLengthEncodingTests.elm
+++ b/exercises/run-length-encoding/RunLengthEncodingTests.elm
@@ -1,41 +1,51 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import RunLengthEncoding exposing (version, decode, encode)
 
 
 tests : Test
 tests =
-    suite "RunLengthEncoding"
+    describe "RunLengthEncoding"
         [ test "the solution is for the correct version of the test"
-            (assertEqual 2 version)
+            (\() -> Expect.equal 2 version)
         , test "encode simple"
-            (assertEqual "2A3B4C" (encode "AABBBCCCC"))
+            (\() -> Expect.equal "2A3B4C" (encode "AABBBCCCC"))
         , test "decode simple"
-            (assertEqual "AABBBCCCC" (decode "2A3B4C"))
+            (\() -> Expect.equal "AABBBCCCC" (decode "2A3B4C"))
         , test "encode with single values"
-            (assertEqual "12WB12W3B24WB"
-                (encode "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB")
+            (\() ->
+                Expect.equal "12WB12W3B24WB"
+                    (encode "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB")
             )
         , test "decode with single values"
-            (assertEqual "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"
-                (decode "12WB12W3B24WB")
+            (\() ->
+                Expect.equal "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"
+                    (decode "12WB12W3B24WB")
             )
         , test "(decode (encode (...)) combination"
-            (assertEqual "zzz ZZ  zZ"
-                (decode (encode "zzz ZZ  zZ"))
+            (\() ->
+                Expect.equal "zzz ZZ  zZ"
+                    (decode (encode "zzz ZZ  zZ"))
             )
         , test "decode with a x10 value"
-            (assertEqual "WWWWWWWWWW"
-                (decode "10W")
+            (\() ->
+                Expect.equal "WWWWWWWWWW"
+                    (decode "10W")
             )
         , test "encode unicode"
-            (assertEqual "⏰3⚽2⭐⏰" (encode "⏰⚽⚽⚽⭐⭐⏰"))
+            (\() -> Expect.equal "⏰3⚽2⭐⏰" (encode "⏰⚽⚽⚽⭐⭐⏰"))
         , test "decode unicode"
-            (assertEqual "⏰⚽⚽⚽⭐⭐⏰" (decode "⏰3⚽2⭐⏰"))
+            (\() -> Expect.equal "⏰⚽⚽⚽⭐⭐⏰" (decode "⏰3⚽2⭐⏰"))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/run-length-encoding/RunLengthEncodingTests.elm
+++ b/exercises/run-length-encoding/RunLengthEncodingTests.elm
@@ -10,36 +10,32 @@ import RunLengthEncoding exposing (version, decode, encode)
 tests : Test
 tests =
     describe "RunLengthEncoding"
-        [ test "the solution is for the correct version of the test"
-            (\() -> Expect.equal 2 version)
-        , test "encode simple"
-            (\() -> Expect.equal "2A3B4C" (encode "AABBBCCCC"))
-        , test "decode simple"
-            (\() -> Expect.equal "AABBBCCCC" (decode "2A3B4C"))
-        , test "encode with single values"
-            (\() ->
+        [ test "the solution is for the correct version of the test" <|
+            \() -> Expect.equal 2 version
+        , test "encode simple" <|
+            \() -> Expect.equal "2A3B4C" (encode "AABBBCCCC")
+        , test "decode simple" <|
+            \() -> Expect.equal "AABBBCCCC" (decode "2A3B4C")
+        , test "encode with single values" <|
+            \() ->
                 Expect.equal "12WB12W3B24WB"
                     (encode "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB")
-            )
-        , test "decode with single values"
-            (\() ->
+        , test "decode with single values" <|
+            \() ->
                 Expect.equal "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"
                     (decode "12WB12W3B24WB")
-            )
-        , test "(decode (encode (...)) combination"
-            (\() ->
+        , test "(decode (encode (...)) combination" <|
+            \() ->
                 Expect.equal "zzz ZZ  zZ"
                     (decode (encode "zzz ZZ  zZ"))
-            )
-        , test "decode with a x10 value"
-            (\() ->
+        , test "decode with a x10 value" <|
+            \() ->
                 Expect.equal "WWWWWWWWWW"
                     (decode "10W")
-            )
-        , test "encode unicode"
-            (\() -> Expect.equal "⏰3⚽2⭐⏰" (encode "⏰⚽⚽⚽⭐⭐⏰"))
-        , test "decode unicode"
-            (\() -> Expect.equal "⏰⚽⚽⚽⭐⭐⏰" (decode "⏰3⚽2⭐⏰"))
+        , test "encode unicode" <|
+            \() -> Expect.equal "⏰3⚽2⭐⏰" (encode "⏰⚽⚽⚽⭐⭐⏰")
+        , test "decode unicode" <|
+            \() -> Expect.equal "⏰⚽⚽⚽⭐⭐⏰" (decode "⏰3⚽2⭐⏰")
         ]
 
 

--- a/exercises/run-length-encoding/elm-package.json
+++ b/exercises/run-length-encoding/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/run-length-encoding/runtests.bat
+++ b/exercises/run-length-encoding/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/run-length-encoding/runtests.sh
+++ b/exercises/run-length-encoding/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/say/SayTests.elm
+++ b/exercises/say/SayTests.elm
@@ -10,88 +10,72 @@ import Say exposing (say, SayError(Negative, TooLarge))
 tests : Test
 tests =
     describe "Series"
-        [ test "one"
-            (\() ->
+        [ test "one" <|
+            \() ->
                 Expect.equal (Ok "one")
                     (say 1)
-            )
-        , test "fourteen"
-            (\() ->
+        , test "fourteen" <|
+            \() ->
                 Expect.equal (Ok "fourteen")
                     (say 14)
-            )
-        , test "twenty"
-            (\() ->
+        , test "twenty" <|
+            \() ->
                 Expect.equal (Ok "twenty")
                     (say 20)
-            )
-        , test "twenty-two"
-            (\() ->
+        , test "twenty-two" <|
+            \() ->
                 Expect.equal (Ok "twenty-two")
                     (say 22)
-            )
-        , test "one hundred"
-            (\() ->
+        , test "one hundred" <|
+            \() ->
                 Expect.equal (Ok "one hundred")
                     (say 100)
-            )
-        , test "one hundred twenty"
-            (\() ->
+        , test "one hundred twenty" <|
+            \() ->
                 Expect.equal (Ok "one hundred and twenty")
                     (say 120)
-            )
-        , test "one hundred twenty-three"
-            (\() ->
+        , test "one hundred twenty-three" <|
+            \() ->
                 Expect.equal (Ok "one hundred and twenty-three")
                     (say 123)
-            )
-        , test "one thousand"
-            (\() ->
+        , test "one thousand" <|
+            \() ->
                 Expect.equal (Ok "one thousand")
                     (say 1000)
-            )
-        , test "one thousand two hundred thirty-four"
-            (\() ->
+        , test "one thousand two hundred thirty-four" <|
+            \() ->
                 Expect.equal (Ok "one thousand two hundred and thirty-four")
                     (say 1234)
-            )
-        , test "one million"
-            (\() ->
+        , test "one million" <|
+            \() ->
                 Expect.equal (Ok "one million")
                     (say 1000000)
-            )
-        , test "one million two"
-            (\() ->
+        , test "one million two" <|
+            \() ->
                 Expect.equal (Ok "one million and two")
                     (say 1000002)
-            )
-        , test "1002345"
-            (\() ->
+        , test "1002345" <|
+            \() ->
                 Expect.equal (Ok "one million two thousand three hundred and forty-five")
                     (say 1002345)
-            )
-        , test "one billion"
-            (\() ->
+        , test "one billion" <|
+            \() ->
                 Expect.equal (Ok "one billion")
                     (say 1000000000)
-            )
-        , test "number too large"
-            (\() ->
+        , test "number too large" <|
+            \() ->
                 Expect.equal (Err TooLarge)
                     (say 10000000000000000)
-            )
-        , test "negative number"
-            (\() ->
+        , test "negative number" <|
+            \() ->
                 Expect.equal (Err Negative)
                     (say -42)
-            )
-        , test "zero"
-            (\() ->
+        , test "zero" <|
+            \() ->
                 Expect.equal (Ok "zero")
                     (say 0)
-            )
-        , test "987654321123"
-            (\() ->
+        , test "987654321123" <|
+            \() ->
                 Expect.equal
                     (Ok
                         ("nine hundred and eighty-seven billion "
@@ -101,7 +85,6 @@ tests =
                         )
                     )
                     (say 987654321123)
-            )
         ]
 
 

--- a/exercises/say/SayTests.elm
+++ b/exercises/say/SayTests.elm
@@ -1,90 +1,113 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Say exposing (say, SayError(Negative, TooLarge))
 
 
 tests : Test
 tests =
-    suite "Series"
+    describe "Series"
         [ test "one"
-            (assertEqual (Ok "one")
-                (say 1)
+            (\() ->
+                Expect.equal (Ok "one")
+                    (say 1)
             )
         , test "fourteen"
-            (assertEqual (Ok "fourteen")
-                (say 14)
+            (\() ->
+                Expect.equal (Ok "fourteen")
+                    (say 14)
             )
         , test "twenty"
-            (assertEqual (Ok "twenty")
-                (say 20)
+            (\() ->
+                Expect.equal (Ok "twenty")
+                    (say 20)
             )
         , test "twenty-two"
-            (assertEqual (Ok "twenty-two")
-                (say 22)
+            (\() ->
+                Expect.equal (Ok "twenty-two")
+                    (say 22)
             )
         , test "one hundred"
-            (assertEqual (Ok "one hundred")
-                (say 100)
+            (\() ->
+                Expect.equal (Ok "one hundred")
+                    (say 100)
             )
         , test "one hundred twenty"
-            (assertEqual (Ok "one hundred and twenty")
-                (say 120)
+            (\() ->
+                Expect.equal (Ok "one hundred and twenty")
+                    (say 120)
             )
         , test "one hundred twenty-three"
-            (assertEqual (Ok "one hundred and twenty-three")
-                (say 123)
+            (\() ->
+                Expect.equal (Ok "one hundred and twenty-three")
+                    (say 123)
             )
         , test "one thousand"
-            (assertEqual (Ok "one thousand")
-                (say 1000)
+            (\() ->
+                Expect.equal (Ok "one thousand")
+                    (say 1000)
             )
         , test "one thousand two hundred thirty-four"
-            (assertEqual (Ok "one thousand two hundred and thirty-four")
-                (say 1234)
+            (\() ->
+                Expect.equal (Ok "one thousand two hundred and thirty-four")
+                    (say 1234)
             )
         , test "one million"
-            (assertEqual (Ok "one million")
-                (say 1000000)
+            (\() ->
+                Expect.equal (Ok "one million")
+                    (say 1000000)
             )
         , test "one million two"
-            (assertEqual (Ok "one million and two")
-                (say 1000002)
+            (\() ->
+                Expect.equal (Ok "one million and two")
+                    (say 1000002)
             )
         , test "1002345"
-            (assertEqual (Ok "one million two thousand three hundred and forty-five")
-                (say 1002345)
+            (\() ->
+                Expect.equal (Ok "one million two thousand three hundred and forty-five")
+                    (say 1002345)
             )
         , test "one billion"
-            (assertEqual (Ok "one billion")
-                (say 1000000000)
+            (\() ->
+                Expect.equal (Ok "one billion")
+                    (say 1000000000)
             )
         , test "number too large"
-            (assertEqual (Err TooLarge)
-                (say 10000000000000000)
+            (\() ->
+                Expect.equal (Err TooLarge)
+                    (say 10000000000000000)
             )
         , test "negative number"
-            (assertEqual (Err Negative)
-                (say -42)
+            (\() ->
+                Expect.equal (Err Negative)
+                    (say -42)
             )
         , test "zero"
-            (assertEqual (Ok "zero")
-                (say 0)
+            (\() ->
+                Expect.equal (Ok "zero")
+                    (say 0)
             )
         , test "987654321123"
-            (assertEqual
-                (Ok
-                    ("nine hundred and eighty-seven billion "
-                        ++ "six hundred and fifty-four million "
-                        ++ "three hundred and twenty-one thousand "
-                        ++ "one hundred and twenty-three"
+            (\() ->
+                Expect.equal
+                    (Ok
+                        ("nine hundred and eighty-seven billion "
+                            ++ "six hundred and fifty-four million "
+                            ++ "three hundred and twenty-one thousand "
+                            ++ "one hundred and twenty-three"
+                        )
                     )
-                )
-                (say 987654321123)
+                    (say 987654321123)
             )
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/say/elm-package.json
+++ b/exercises/say/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/say/runtests.bat
+++ b/exercises/say/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/say/runtests.sh
+++ b/exercises/say/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/series/SeriesTests.elm
+++ b/exercises/series/SeriesTests.elm
@@ -10,46 +10,38 @@ import Series exposing (slices)
 tests : Test
 tests =
     describe "Series"
-        [ test "slices of one"
-            (\() ->
+        [ test "slices of one" <|
+            \() ->
                 Expect.equal (Ok [ [ 0 ], [ 1 ], [ 2 ], [ 3 ], [ 4 ] ])
                     (slices 1 "01234")
-            )
-        , test "slices of two"
-            (\() ->
+        , test "slices of two" <|
+            \() ->
                 Expect.equal (Ok [ [ 9, 7 ], [ 7, 8 ], [ 8, 6 ], [ 6, 7 ], [ 7, 5 ], [ 5, 6 ], [ 6, 4 ] ])
                     (slices 2 "97867564")
-            )
-        , test "slices of three"
-            (\() ->
+        , test "slices of three" <|
+            \() ->
                 Expect.equal (Ok [ [ 9, 7, 8 ], [ 7, 8, 6 ], [ 8, 6, 7 ], [ 6, 7, 5 ], [ 7, 5, 6 ], [ 5, 6, 4 ] ])
                     (slices 3 "97867564")
-            )
-        , test "slices of four"
-            (\() ->
+        , test "slices of four" <|
+            \() ->
                 Expect.equal (Ok [ [ 0, 1, 2, 3 ], [ 1, 2, 3, 4 ] ])
                     (slices 4 "01234")
-            )
-        , test "slices of five"
-            (\() ->
+        , test "slices of five" <|
+            \() ->
                 Expect.equal (Ok [ [ 0, 1, 2, 3, 4 ] ])
                     (slices 5 "01234")
-            )
-        , test "overly long slice"
-            (\() ->
+        , test "overly long slice" <|
+            \() ->
                 Expect.equal (Ok [])
                     (slices 4 "012")
-            )
-        , test "overly short slice"
-            (\() ->
+        , test "overly short slice" <|
+            \() ->
                 Expect.equal (Err ("Invalid size: 0"))
                     (slices 0 "01234")
-            )
-        , test "input has non numbers"
-            (\() ->
+        , test "input has non numbers" <|
+            \() ->
                 Expect.equal (Err "could not convert string 'a' to an Int")
                     (slices 2 "0123abc")
-            )
         ]
 
 

--- a/exercises/series/SeriesTests.elm
+++ b/exercises/series/SeriesTests.elm
@@ -1,47 +1,61 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Series exposing (slices)
 
 
 tests : Test
 tests =
-    suite "Series"
+    describe "Series"
         [ test "slices of one"
-            (assertEqual (Ok [ [ 0 ], [ 1 ], [ 2 ], [ 3 ], [ 4 ] ])
-                (slices 1 "01234")
+            (\() ->
+                Expect.equal (Ok [ [ 0 ], [ 1 ], [ 2 ], [ 3 ], [ 4 ] ])
+                    (slices 1 "01234")
             )
         , test "slices of two"
-            (assertEqual (Ok [ [ 9, 7 ], [ 7, 8 ], [ 8, 6 ], [ 6, 7 ], [ 7, 5 ], [ 5, 6 ], [ 6, 4 ] ])
-                (slices 2 "97867564")
+            (\() ->
+                Expect.equal (Ok [ [ 9, 7 ], [ 7, 8 ], [ 8, 6 ], [ 6, 7 ], [ 7, 5 ], [ 5, 6 ], [ 6, 4 ] ])
+                    (slices 2 "97867564")
             )
         , test "slices of three"
-            (assertEqual (Ok [ [ 9, 7, 8 ], [ 7, 8, 6 ], [ 8, 6, 7 ], [ 6, 7, 5 ], [ 7, 5, 6 ], [ 5, 6, 4 ] ])
-                (slices 3 "97867564")
+            (\() ->
+                Expect.equal (Ok [ [ 9, 7, 8 ], [ 7, 8, 6 ], [ 8, 6, 7 ], [ 6, 7, 5 ], [ 7, 5, 6 ], [ 5, 6, 4 ] ])
+                    (slices 3 "97867564")
             )
         , test "slices of four"
-            (assertEqual (Ok [ [ 0, 1, 2, 3 ], [ 1, 2, 3, 4 ] ])
-                (slices 4 "01234")
+            (\() ->
+                Expect.equal (Ok [ [ 0, 1, 2, 3 ], [ 1, 2, 3, 4 ] ])
+                    (slices 4 "01234")
             )
         , test "slices of five"
-            (assertEqual (Ok [ [ 0, 1, 2, 3, 4 ] ])
-                (slices 5 "01234")
+            (\() ->
+                Expect.equal (Ok [ [ 0, 1, 2, 3, 4 ] ])
+                    (slices 5 "01234")
             )
         , test "overly long slice"
-            (assertEqual (Ok [])
-                (slices 4 "012")
+            (\() ->
+                Expect.equal (Ok [])
+                    (slices 4 "012")
             )
         , test "overly short slice"
-            (assertEqual (Err ("Invalid size: 0"))
-                (slices 0 "01234")
+            (\() ->
+                Expect.equal (Err ("Invalid size: 0"))
+                    (slices 0 "01234")
             )
         , test "input has non numbers"
-            (assertEqual (Err "could not convert string 'a' to an Int")
-                (slices 2 "0123abc")
+            (\() ->
+                Expect.equal (Err "could not convert string 'a' to an Int")
+                    (slices 2 "0123abc")
             )
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/series/elm-package.json
+++ b/exercises/series/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/series/runtests.bat
+++ b/exercises/series/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/series/runtests.sh
+++ b/exercises/series/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/space-age/SpaceAgeTests.elm
+++ b/exercises/space-age/SpaceAgeTests.elm
@@ -1,31 +1,37 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import SpaceAge exposing (Planet(..), ageOn)
 
 
 tests : Test
 tests =
-    suite "SpaceAge"
+    describe "SpaceAge"
         [ test "age in earth years"
-            (assertEqual 32 (round (ageOn Earth 1000000000)))
+            (\() -> Expect.equal 32 (round (ageOn Earth 1000000000)))
         , test "age in mercury years"
-            (assertEqual 281 (round (ageOn Mercury 2134835688)))
+            (\() -> Expect.equal 281 (round (ageOn Mercury 2134835688)))
         , test "age in venus years"
-            (assertEqual 10 (round (ageOn Venus 189839836)))
+            (\() -> Expect.equal 10 (round (ageOn Venus 189839836)))
         , test "age on mars"
-            (assertEqual 39 (round (ageOn Mars 2329871239)))
+            (\() -> Expect.equal 39 (round (ageOn Mars 2329871239)))
         , test "age on jupiter"
-            (assertEqual 2 (round (ageOn Jupiter 901876382)))
+            (\() -> Expect.equal 2 (round (ageOn Jupiter 901876382)))
         , test "age on saturn"
-            (assertEqual 3 (round (ageOn Saturn 3000000000)))
+            (\() -> Expect.equal 3 (round (ageOn Saturn 3000000000)))
         , test "age on uranus"
-            (assertEqual 1 (round (ageOn Uranus 3210123456)))
+            (\() -> Expect.equal 1 (round (ageOn Uranus 3210123456)))
         , test "age on neptune"
-            (assertEqual 2 (round (ageOn Neptune 8210123456)))
+            (\() -> Expect.equal 2 (round (ageOn Neptune 8210123456)))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/space-age/SpaceAgeTests.elm
+++ b/exercises/space-age/SpaceAgeTests.elm
@@ -10,22 +10,22 @@ import SpaceAge exposing (Planet(..), ageOn)
 tests : Test
 tests =
     describe "SpaceAge"
-        [ test "age in earth years"
-            (\() -> Expect.equal 32 (round (ageOn Earth 1000000000)))
-        , test "age in mercury years"
-            (\() -> Expect.equal 281 (round (ageOn Mercury 2134835688)))
-        , test "age in venus years"
-            (\() -> Expect.equal 10 (round (ageOn Venus 189839836)))
-        , test "age on mars"
-            (\() -> Expect.equal 39 (round (ageOn Mars 2329871239)))
-        , test "age on jupiter"
-            (\() -> Expect.equal 2 (round (ageOn Jupiter 901876382)))
-        , test "age on saturn"
-            (\() -> Expect.equal 3 (round (ageOn Saturn 3000000000)))
-        , test "age on uranus"
-            (\() -> Expect.equal 1 (round (ageOn Uranus 3210123456)))
-        , test "age on neptune"
-            (\() -> Expect.equal 2 (round (ageOn Neptune 8210123456)))
+        [ test "age in earth years" <|
+            \() -> Expect.equal 32 (round (ageOn Earth 1000000000))
+        , test "age in mercury years" <|
+            \() -> Expect.equal 281 (round (ageOn Mercury 2134835688))
+        , test "age in venus years" <|
+            \() -> Expect.equal 10 (round (ageOn Venus 189839836))
+        , test "age on mars" <|
+            \() -> Expect.equal 39 (round (ageOn Mars 2329871239))
+        , test "age on jupiter" <|
+            \() -> Expect.equal 2 (round (ageOn Jupiter 901876382))
+        , test "age on saturn" <|
+            \() -> Expect.equal 3 (round (ageOn Saturn 3000000000))
+        , test "age on uranus" <|
+            \() -> Expect.equal 1 (round (ageOn Uranus 3210123456))
+        , test "age on neptune" <|
+            \() -> Expect.equal 2 (round (ageOn Neptune 8210123456))
         ]
 
 

--- a/exercises/space-age/elm-package.json
+++ b/exercises/space-age/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/space-age/runtests.bat
+++ b/exercises/space-age/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/space-age/runtests.sh
+++ b/exercises/space-age/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/strain/StrainTests.elm
+++ b/exercises/strain/StrainTests.elm
@@ -31,66 +31,54 @@ lessThanTen num =
 tests : Test
 tests =
     describe "Strain"
-        [ test "empty keep"
-            (\() ->
+        [ test "empty keep" <|
+            \() ->
                 Expect.equal []
                     (keep lessThanTen [])
-            )
-        , test "keep everything"
-            (\() ->
+        , test "keep everything" <|
+            \() ->
                 Expect.equal [ 1, 2, 3 ]
                     (keep lessThanTen [ 1, 2, 3 ])
-            )
-        , test "keep first and last"
-            (\() ->
+        , test "keep first and last" <|
+            \() ->
                 Expect.equal [ 1, 3 ]
                     (keep odd [ 1, 2, 3 ])
-            )
-        , test "keep nothing"
-            (\() ->
+        , test "keep nothing" <|
+            \() ->
                 Expect.equal []
                     (keep even [ 1, 3, 5, 7 ])
-            )
-        , test "keep neither first nor last"
-            (\() ->
+        , test "keep neither first nor last" <|
+            \() ->
                 Expect.equal [ 2 ]
                     (keep even [ 1, 2, 3 ])
-            )
-        , test "keep strings"
-            (\() ->
+        , test "keep strings" <|
+            \() ->
                 Expect.equal [ "zebra", "zombies", "zealot" ]
                     (keep (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
-            )
-        , test "empty discard"
-            (\() ->
+        , test "empty discard" <|
+            \() ->
                 Expect.equal []
                     (discard lessThanTen [])
-            )
-        , test "discard everything"
-            (\() ->
+        , test "discard everything" <|
+            \() ->
                 Expect.equal []
                     (discard lessThanTen [ 1, 2, 3 ])
-            )
-        , test "discard first and last"
-            (\() ->
+        , test "discard first and last" <|
+            \() ->
                 Expect.equal [ 2 ]
                     (discard odd [ 1, 2, 3 ])
-            )
-        , test "discard nothing"
-            (\() ->
+        , test "discard nothing" <|
+            \() ->
                 Expect.equal [ 1, 3, 5, 7 ]
                     (discard even [ 1, 3, 5, 7 ])
-            )
-        , test "discard neither first nor last"
-            (\() ->
+        , test "discard neither first nor last" <|
+            \() ->
                 Expect.equal [ 1, 3 ]
                     (discard even [ 1, 2, 3 ])
-            )
-        , test "discard strings"
-            (\() ->
+        , test "discard strings" <|
+            \() ->
                 Expect.equal [ "apple", "banana", "cherimoya" ]
                     (discard (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
-            )
         ]
 
 

--- a/exercises/strain/StrainTests.elm
+++ b/exercises/strain/StrainTests.elm
@@ -1,6 +1,9 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Strain exposing (keep, discard)
 import String
 
@@ -27,58 +30,73 @@ lessThanTen num =
 
 tests : Test
 tests =
-    suite "Strain"
+    describe "Strain"
         [ test "empty keep"
-            (assertEqual []
-                (keep lessThanTen [])
+            (\() ->
+                Expect.equal []
+                    (keep lessThanTen [])
             )
         , test "keep everything"
-            (assertEqual [ 1, 2, 3 ]
-                (keep lessThanTen [ 1, 2, 3 ])
+            (\() ->
+                Expect.equal [ 1, 2, 3 ]
+                    (keep lessThanTen [ 1, 2, 3 ])
             )
         , test "keep first and last"
-            (assertEqual [ 1, 3 ]
-                (keep odd [ 1, 2, 3 ])
+            (\() ->
+                Expect.equal [ 1, 3 ]
+                    (keep odd [ 1, 2, 3 ])
             )
         , test "keep nothing"
-            (assertEqual []
-                (keep even [ 1, 3, 5, 7 ])
+            (\() ->
+                Expect.equal []
+                    (keep even [ 1, 3, 5, 7 ])
             )
         , test "keep neither first nor last"
-            (assertEqual [ 2 ]
-                (keep even [ 1, 2, 3 ])
+            (\() ->
+                Expect.equal [ 2 ]
+                    (keep even [ 1, 2, 3 ])
             )
         , test "keep strings"
-            (assertEqual [ "zebra", "zombies", "zealot" ]
-                (keep (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
+            (\() ->
+                Expect.equal [ "zebra", "zombies", "zealot" ]
+                    (keep (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
             )
         , test "empty discard"
-            (assertEqual []
-                (discard lessThanTen [])
+            (\() ->
+                Expect.equal []
+                    (discard lessThanTen [])
             )
         , test "discard everything"
-            (assertEqual []
-                (discard lessThanTen [ 1, 2, 3 ])
+            (\() ->
+                Expect.equal []
+                    (discard lessThanTen [ 1, 2, 3 ])
             )
         , test "discard first and last"
-            (assertEqual [ 2 ]
-                (discard odd [ 1, 2, 3 ])
+            (\() ->
+                Expect.equal [ 2 ]
+                    (discard odd [ 1, 2, 3 ])
             )
         , test "discard nothing"
-            (assertEqual [ 1, 3, 5, 7 ]
-                (discard even [ 1, 3, 5, 7 ])
+            (\() ->
+                Expect.equal [ 1, 3, 5, 7 ]
+                    (discard even [ 1, 3, 5, 7 ])
             )
         , test "discard neither first nor last"
-            (assertEqual [ 1, 3 ]
-                (discard even [ 1, 2, 3 ])
+            (\() ->
+                Expect.equal [ 1, 3 ]
+                    (discard even [ 1, 2, 3 ])
             )
         , test "discard strings"
-            (assertEqual [ "apple", "banana", "cherimoya" ]
-                (discard (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
+            (\() ->
+                Expect.equal [ "apple", "banana", "cherimoya" ]
+                    (discard (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
             )
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/strain/elm-package.json
+++ b/exercises/strain/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/strain/runtests.bat
+++ b/exercises/strain/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/strain/runtests.sh
+++ b/exercises/strain/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/sublist/SublistTests.elm
+++ b/exercises/sublist/SublistTests.elm
@@ -1,53 +1,59 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Sublist exposing (version, sublist, ListComparison(..))
 
 
 tests : Test
 tests =
-    suite "Sublist"
+    describe "Sublist"
         [ test "the solution is for the correct version of the test"
-            (assertEqual 2 version)
+            (\() -> Expect.equal 2 version)
         , test "empty equals empty"
-            (assertEqual Equal (sublist [] []))
+            (\() -> Expect.equal Equal (sublist [] []))
         , test "empty is a sublist of anything"
-            (assertEqual Sublist (sublist [] [ 1, 2 ]))
+            (\() -> Expect.equal Sublist (sublist [] [ 1, 2 ]))
         , test "anything is a superlist of empty"
-            (assertEqual Superlist (sublist [ 1, 2 ] []))
+            (\() -> Expect.equal Superlist (sublist [ 1, 2 ] []))
         , test "1 is not 2"
-            (assertEqual Unequal (sublist [ 1 ] [ 2 ]))
+            (\() -> Expect.equal Unequal (sublist [ 1 ] [ 2 ]))
         , test "compare larger equal lists"
-            (assertEqual Equal (sublist [ 1, 1, 1 ] [ 1, 1, 1 ]))
+            (\() -> Expect.equal Equal (sublist [ 1, 1, 1 ] [ 1, 1, 1 ]))
         , test "sublist at start"
-            (assertEqual Sublist (sublist [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ]))
+            (\() -> Expect.equal Sublist (sublist [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ]))
         , test "sublist in the middle"
-            (assertEqual Sublist (sublist [ 4, 3, 2 ] [ 5, 4, 3, 2, 1 ]))
+            (\() -> Expect.equal Sublist (sublist [ 4, 3, 2 ] [ 5, 4, 3, 2, 1 ]))
         , test "sublist at end"
-            (assertEqual Sublist (sublist [ 3, 4, 5 ] [ 1, 2, 3, 4, 5 ]))
+            (\() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] [ 1, 2, 3, 4, 5 ]))
         , test "partially matching sublist at start"
-            (assertEqual Sublist (sublist [ 1, 1, 2 ] [ 1, 1, 1, 2 ]))
+            (\() -> Expect.equal Sublist (sublist [ 1, 1, 2 ] [ 1, 1, 1, 2 ]))
         , test "sublist early in huge list"
-            (assertEqual Sublist (sublist [ 3, 4, 5 ] [1..100000]))
+            (\() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] [1..100000]))
         , test "huge sublist not in list"
-            (assertEqual Unequal (sublist [10..5001] [1..5000]))
+            (\() -> Expect.equal Unequal (sublist [10..5001] [1..5000]))
         , test "superlist at start"
-            (assertEqual Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 1, 2, 3 ]))
+            (\() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 1, 2, 3 ]))
         , test "superlist in middle"
-            (assertEqual Superlist (sublist [ 5, 4, 3, 2, 1 ] [ 4, 3, 2 ]))
+            (\() -> Expect.equal Superlist (sublist [ 5, 4, 3, 2, 1 ] [ 4, 3, 2 ]))
         , test "superlist at end"
-            (assertEqual Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 3, 4, 5 ]))
+            (\() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 3, 4, 5 ]))
         , test "partially matching superlist at start"
-            (assertEqual Superlist (sublist [ 1, 1, 1, 2 ] [ 1, 1, 2 ]))
+            (\() -> Expect.equal Superlist (sublist [ 1, 1, 1, 2 ] [ 1, 1, 2 ]))
         , test "superlist early in huge list"
-            (assertEqual Superlist (sublist [1..100000] [ 3, 4, 5 ]))
+            (\() -> Expect.equal Superlist (sublist [1..100000] [ 3, 4, 5 ]))
         , test "recurring values sublist"
-            (assertEqual Sublist (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 1, 2, 3, 2, 1 ]))
+            (\() -> Expect.equal Sublist (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 1, 2, 3, 2, 1 ]))
         , test "recurring values unequal"
-            (assertEqual Unequal (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 3, 2, 3, 2, 1 ]))
+            (\() -> Expect.equal Unequal (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 3, 2, 3, 2, 1 ]))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/sublist/SublistTests.elm
+++ b/exercises/sublist/SublistTests.elm
@@ -10,44 +10,44 @@ import Sublist exposing (version, sublist, ListComparison(..))
 tests : Test
 tests =
     describe "Sublist"
-        [ test "the solution is for the correct version of the test"
-            (\() -> Expect.equal 2 version)
-        , test "empty equals empty"
-            (\() -> Expect.equal Equal (sublist [] []))
-        , test "empty is a sublist of anything"
-            (\() -> Expect.equal Sublist (sublist [] [ 1, 2 ]))
-        , test "anything is a superlist of empty"
-            (\() -> Expect.equal Superlist (sublist [ 1, 2 ] []))
-        , test "1 is not 2"
-            (\() -> Expect.equal Unequal (sublist [ 1 ] [ 2 ]))
-        , test "compare larger equal lists"
-            (\() -> Expect.equal Equal (sublist [ 1, 1, 1 ] [ 1, 1, 1 ]))
-        , test "sublist at start"
-            (\() -> Expect.equal Sublist (sublist [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ]))
-        , test "sublist in the middle"
-            (\() -> Expect.equal Sublist (sublist [ 4, 3, 2 ] [ 5, 4, 3, 2, 1 ]))
-        , test "sublist at end"
-            (\() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] [ 1, 2, 3, 4, 5 ]))
-        , test "partially matching sublist at start"
-            (\() -> Expect.equal Sublist (sublist [ 1, 1, 2 ] [ 1, 1, 1, 2 ]))
-        , test "sublist early in huge list"
-            (\() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] [1..100000]))
-        , test "huge sublist not in list"
-            (\() -> Expect.equal Unequal (sublist [10..5001] [1..5000]))
-        , test "superlist at start"
-            (\() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 1, 2, 3 ]))
-        , test "superlist in middle"
-            (\() -> Expect.equal Superlist (sublist [ 5, 4, 3, 2, 1 ] [ 4, 3, 2 ]))
-        , test "superlist at end"
-            (\() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 3, 4, 5 ]))
-        , test "partially matching superlist at start"
-            (\() -> Expect.equal Superlist (sublist [ 1, 1, 1, 2 ] [ 1, 1, 2 ]))
-        , test "superlist early in huge list"
-            (\() -> Expect.equal Superlist (sublist [1..100000] [ 3, 4, 5 ]))
-        , test "recurring values sublist"
-            (\() -> Expect.equal Sublist (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 1, 2, 3, 2, 1 ]))
-        , test "recurring values unequal"
-            (\() -> Expect.equal Unequal (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 3, 2, 3, 2, 1 ]))
+        [ test "the solution is for the correct version of the test" <|
+            \() -> Expect.equal 2 version
+        , test "empty equals empty" <|
+            \() -> Expect.equal Equal (sublist [] [])
+        , test "empty is a sublist of anything" <|
+            \() -> Expect.equal Sublist (sublist [] [ 1, 2 ])
+        , test "anything is a superlist of empty" <|
+            \() -> Expect.equal Superlist (sublist [ 1, 2 ] [])
+        , test "1 is not 2" <|
+            \() -> Expect.equal Unequal (sublist [ 1 ] [ 2 ])
+        , test "compare larger equal lists" <|
+            \() -> Expect.equal Equal (sublist [ 1, 1, 1 ] [ 1, 1, 1 ])
+        , test "sublist at start" <|
+            \() -> Expect.equal Sublist (sublist [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ])
+        , test "sublist in the middle" <|
+            \() -> Expect.equal Sublist (sublist [ 4, 3, 2 ] [ 5, 4, 3, 2, 1 ])
+        , test "sublist at end" <|
+            \() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] [ 1, 2, 3, 4, 5 ])
+        , test "partially matching sublist at start" <|
+            \() -> Expect.equal Sublist (sublist [ 1, 1, 2 ] [ 1, 1, 1, 2 ])
+        , test "sublist early in huge list" <|
+            \() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] [1..100000])
+        , test "huge sublist not in list" <|
+            \() -> Expect.equal Unequal (sublist [10..5001] [1..5000])
+        , test "superlist at start" <|
+            \() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 1, 2, 3 ])
+        , test "superlist in middle" <|
+            \() -> Expect.equal Superlist (sublist [ 5, 4, 3, 2, 1 ] [ 4, 3, 2 ])
+        , test "superlist at end" <|
+            \() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 3, 4, 5 ])
+        , test "partially matching superlist at start" <|
+            \() -> Expect.equal Superlist (sublist [ 1, 1, 1, 2 ] [ 1, 1, 2 ])
+        , test "superlist early in huge list" <|
+            \() -> Expect.equal Superlist (sublist [1..100000] [ 3, 4, 5 ])
+        , test "recurring values sublist" <|
+            \() -> Expect.equal Sublist (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 1, 2, 3, 2, 1 ])
+        , test "recurring values unequal" <|
+            \() -> Expect.equal Unequal (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 3, 2, 3, 2, 1 ])
         ]
 
 

--- a/exercises/sublist/elm-package.json
+++ b/exercises/sublist/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/sublist/runtests.bat
+++ b/exercises/sublist/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/sublist/runtests.sh
+++ b/exercises/sublist/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/sum-of-multiples/SumOfMultiplesTests.elm
+++ b/exercises/sum-of-multiples/SumOfMultiplesTests.elm
@@ -10,12 +10,18 @@ import SumOfMultiples exposing (sumOfMultiples)
 tests : Test
 tests =
     describe "Sum Of Multiples"
-        [ test "[3, 5] 15" (\() -> Expect.equal 45 (sumOfMultiples [ 3, 5 ] 15))
-        , test "[7, 13, 17] 20" (\() -> Expect.equal 51 (sumOfMultiples [ 7, 13, 17 ] 20))
-        , test "[4, 6] 15" (\() -> Expect.equal 30 (sumOfMultiples [ 4, 6 ] 15))
-        , test "[5, 6, 8] 150" (\() -> Expect.equal 4419 (sumOfMultiples [ 5, 6, 8 ] 150))
-        , test "[43, 47] 10000" (\() -> Expect.equal 2203160 (sumOfMultiples [ 43, 47 ] 10000))
-        , test "[5, 25] 51" (\() -> Expect.equal 275 (sumOfMultiples [ 5, 25 ] 51))
+        [ test "[3, 5] 15" <|
+            \() -> Expect.equal 45 (sumOfMultiples [ 3, 5 ] 15)
+        , test "[7, 13, 17] 20" <|
+            \() -> Expect.equal 51 (sumOfMultiples [ 7, 13, 17 ] 20)
+        , test "[4, 6] 15" <|
+            \() -> Expect.equal 30 (sumOfMultiples [ 4, 6 ] 15)
+        , test "[5, 6, 8] 150" <|
+            \() -> Expect.equal 4419 (sumOfMultiples [ 5, 6, 8 ] 150)
+        , test "[43, 47] 10000" <|
+            \() -> Expect.equal 2203160 (sumOfMultiples [ 43, 47 ] 10000)
+        , test "[5, 25] 51" <|
+            \() -> Expect.equal 275 (sumOfMultiples [ 5, 25 ] 51)
         ]
 
 

--- a/exercises/sum-of-multiples/SumOfMultiplesTests.elm
+++ b/exercises/sum-of-multiples/SumOfMultiplesTests.elm
@@ -1,21 +1,27 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import SumOfMultiples exposing (sumOfMultiples)
 
 
 tests : Test
 tests =
-    suite "Sum Of Multiples"
-        [ test "[3, 5] 15" (assertEqual 45 (sumOfMultiples [ 3, 5 ] 15))
-        , test "[7, 13, 17] 20" (assertEqual 51 (sumOfMultiples [ 7, 13, 17 ] 20))
-        , test "[4, 6] 15" (assertEqual 30 (sumOfMultiples [ 4, 6 ] 15))
-        , test "[5, 6, 8] 150" (assertEqual 4419 (sumOfMultiples [ 5, 6, 8 ] 150))
-        , test "[43, 47] 10000" (assertEqual 2203160 (sumOfMultiples [ 43, 47 ] 10000))
-        , test "[5, 25] 51" (assertEqual 275 (sumOfMultiples [ 5, 25 ] 51))
+    describe "Sum Of Multiples"
+        [ test "[3, 5] 15" (\() -> Expect.equal 45 (sumOfMultiples [ 3, 5 ] 15))
+        , test "[7, 13, 17] 20" (\() -> Expect.equal 51 (sumOfMultiples [ 7, 13, 17 ] 20))
+        , test "[4, 6] 15" (\() -> Expect.equal 30 (sumOfMultiples [ 4, 6 ] 15))
+        , test "[5, 6, 8] 150" (\() -> Expect.equal 4419 (sumOfMultiples [ 5, 6, 8 ] 150))
+        , test "[43, 47] 10000" (\() -> Expect.equal 2203160 (sumOfMultiples [ 43, 47 ] 10000))
+        , test "[5, 25] 51" (\() -> Expect.equal 275 (sumOfMultiples [ 5, 25 ] 51))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/sum-of-multiples/elm-package.json
+++ b/exercises/sum-of-multiples/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/sum-of-multiples/runtests.bat
+++ b/exercises/sum-of-multiples/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/sum-of-multiples/runtests.sh
+++ b/exercises/sum-of-multiples/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/triangle/TriangleTests.elm
+++ b/exercises/triangle/TriangleTests.elm
@@ -1,47 +1,51 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
-import Triangle exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
+import Triangle exposing (triangleKind, Triangle(..))
 
 
 tests : Test
 tests =
-    suite "triangleKind"
-        [ test "the solution is for the correct version of the test"
-            (assertEqual 2 version)
-        , test "equilateral triangles have equal sides"
-            (assertEqual (Ok Equilateral) (triangleKind 2 2 2))
+    describe "triangleKind"
+        [ test "equilateral triangles have equal sides"
+            (\() -> Expect.equal (Ok Equilateral) (triangleKind 2 2 2))
         , test "larger equilateral triangles also have equal sides"
-            (assertEqual (Ok Equilateral) (triangleKind 10 10 10))
+            (\() -> Expect.equal (Ok Equilateral) (triangleKind 10 10 10))
         , test "isosceles triangles have last two sides equal"
-            (assertEqual (Ok Isosceles) (triangleKind 3 4 4))
+            (\() -> Expect.equal (Ok Isosceles) (triangleKind 3 4 4))
         , test "isosceles triangles have first and last sides equal"
-            (assertEqual (Ok Isosceles) (triangleKind 4 3 4))
+            (\() -> Expect.equal (Ok Isosceles) (triangleKind 4 3 4))
         , test "isosceles triangles have two first sides equal"
-            (assertEqual (Ok Isosceles) (triangleKind 4 4 3))
+            (\() -> Expect.equal (Ok Isosceles) (triangleKind 4 4 3))
         , test "isosceles triangles have in fact exactly two sides equal"
-            (assertEqual (Ok Isosceles) (triangleKind 10 10 2))
+            (\() -> Expect.equal (Ok Isosceles) (triangleKind 10 10 2))
         , test "scalene triangles have no equal sides"
-            (assertEqual (Ok Scalene) (triangleKind 3 4 5))
+            (\() -> Expect.equal (Ok Scalene) (triangleKind 3 4 5))
         , test "scalene triangles have no equal sides at a larger scale too"
-            (assertEqual (Ok Scalene) (triangleKind 10 11 12))
+            (\() -> Expect.equal (Ok Scalene) (triangleKind 10 11 12))
         , test "scalene triangles have no equal sides at a larger scale too 2"
-            (assertEqual (Ok Scalene) (triangleKind 5 4 2))
+            (\() -> Expect.equal (Ok Scalene) (triangleKind 5 4 2))
         , test "very small triangles are legal"
-            (assertEqual (Ok Scalene) (triangleKind 0.4 0.6 0.3))
+            (\() -> Expect.equal (Ok Scalene) (triangleKind 0.4 0.6 0.3))
         , test "triangles with no size are illegal"
-            (assertEqual (Err "Invalid lengths") (triangleKind 0 0 0))
+            (\() -> Expect.equal (Err "Invalid lengths") (triangleKind 0 0 0))
         , test "triangles with negative sides are illegal"
-            (assertEqual (Err "Invalid lengths") (triangleKind 3 4 -5))
+            (\() -> Expect.equal (Err "Invalid lengths") (triangleKind 3 4 -5))
         , test "triangles violating triangle inequality are illegal 1"
-            (assertEqual (Err "Violates inequality") (triangleKind 1 1 3))
+            (\() -> Expect.equal (Err "Violates inequality") (triangleKind 1 1 3))
         , test "triangles violating triangle inequality are illegal 2"
-            (assertEqual (Err "Violates inequality") (triangleKind 2 4 2))
+            (\() -> Expect.equal (Err "Violates inequality") (triangleKind 2 4 2))
         , test "triangles violating triangle inequality are illegal 3"
-            (assertEqual (Err "Violates inequality") (triangleKind 7 3 2))
+            (\() -> Expect.equal (Err "Violates inequality") (triangleKind 7 3 2))
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/triangle/TriangleTests.elm
+++ b/exercises/triangle/TriangleTests.elm
@@ -10,36 +10,36 @@ import Triangle exposing (triangleKind, Triangle(..))
 tests : Test
 tests =
     describe "triangleKind"
-        [ test "equilateral triangles have equal sides"
-            (\() -> Expect.equal (Ok Equilateral) (triangleKind 2 2 2))
-        , test "larger equilateral triangles also have equal sides"
-            (\() -> Expect.equal (Ok Equilateral) (triangleKind 10 10 10))
-        , test "isosceles triangles have last two sides equal"
-            (\() -> Expect.equal (Ok Isosceles) (triangleKind 3 4 4))
-        , test "isosceles triangles have first and last sides equal"
-            (\() -> Expect.equal (Ok Isosceles) (triangleKind 4 3 4))
-        , test "isosceles triangles have two first sides equal"
-            (\() -> Expect.equal (Ok Isosceles) (triangleKind 4 4 3))
-        , test "isosceles triangles have in fact exactly two sides equal"
-            (\() -> Expect.equal (Ok Isosceles) (triangleKind 10 10 2))
-        , test "scalene triangles have no equal sides"
-            (\() -> Expect.equal (Ok Scalene) (triangleKind 3 4 5))
-        , test "scalene triangles have no equal sides at a larger scale too"
-            (\() -> Expect.equal (Ok Scalene) (triangleKind 10 11 12))
-        , test "scalene triangles have no equal sides at a larger scale too 2"
-            (\() -> Expect.equal (Ok Scalene) (triangleKind 5 4 2))
-        , test "very small triangles are legal"
-            (\() -> Expect.equal (Ok Scalene) (triangleKind 0.4 0.6 0.3))
-        , test "triangles with no size are illegal"
-            (\() -> Expect.equal (Err "Invalid lengths") (triangleKind 0 0 0))
-        , test "triangles with negative sides are illegal"
-            (\() -> Expect.equal (Err "Invalid lengths") (triangleKind 3 4 -5))
-        , test "triangles violating triangle inequality are illegal 1"
-            (\() -> Expect.equal (Err "Violates inequality") (triangleKind 1 1 3))
-        , test "triangles violating triangle inequality are illegal 2"
-            (\() -> Expect.equal (Err "Violates inequality") (triangleKind 2 4 2))
-        , test "triangles violating triangle inequality are illegal 3"
-            (\() -> Expect.equal (Err "Violates inequality") (triangleKind 7 3 2))
+        [ test "equilateral triangles have equal sides" <|
+            \() -> Expect.equal (Ok Equilateral) (triangleKind 2 2 2)
+        , test "larger equilateral triangles also have equal sides" <|
+            \() -> Expect.equal (Ok Equilateral) (triangleKind 10 10 10)
+        , test "isosceles triangles have last two sides equal" <|
+            \() -> Expect.equal (Ok Isosceles) (triangleKind 3 4 4)
+        , test "isosceles triangles have first and last sides equal" <|
+            \() -> Expect.equal (Ok Isosceles) (triangleKind 4 3 4)
+        , test "isosceles triangles have two first sides equal" <|
+            \() -> Expect.equal (Ok Isosceles) (triangleKind 4 4 3)
+        , test "isosceles triangles have in fact exactly two sides equal" <|
+            \() -> Expect.equal (Ok Isosceles) (triangleKind 10 10 2)
+        , test "scalene triangles have no equal sides" <|
+            \() -> Expect.equal (Ok Scalene) (triangleKind 3 4 5)
+        , test "scalene triangles have no equal sides at a larger scale too" <|
+            \() -> Expect.equal (Ok Scalene) (triangleKind 10 11 12)
+        , test "scalene triangles have no equal sides at a larger scale too 2" <|
+            \() -> Expect.equal (Ok Scalene) (triangleKind 5 4 2)
+        , test "very small triangles are legal" <|
+            \() -> Expect.equal (Ok Scalene) (triangleKind 0.4 0.6 0.3)
+        , test "triangles with no size are illegal" <|
+            \() -> Expect.equal (Err "Invalid lengths") (triangleKind 0 0 0)
+        , test "triangles with negative sides are illegal" <|
+            \() -> Expect.equal (Err "Invalid lengths") (triangleKind 3 4 -5)
+        , test "triangles violating triangle inequality are illegal 1" <|
+            \() -> Expect.equal (Err "Violates inequality") (triangleKind 1 1 3)
+        , test "triangles violating triangle inequality are illegal 2" <|
+            \() -> Expect.equal (Err "Violates inequality") (triangleKind 2 4 2)
+        , test "triangles violating triangle inequality are illegal 3" <|
+            \() -> Expect.equal (Err "Violates inequality") (triangleKind 7 3 2)
         ]
 
 

--- a/exercises/triangle/elm-package.json
+++ b/exercises/triangle/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/triangle/runtests.bat
+++ b/exercises/triangle/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/triangle/runtests.sh
+++ b/exercises/triangle/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js

--- a/exercises/word-count/WordCountTests.elm
+++ b/exercises/word-count/WordCountTests.elm
@@ -1,40 +1,52 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+import Test exposing (..)
+import Expect
 import Dict exposing (Dict)
 import WordCount exposing (wordCount)
 
 
 tests : Test
 tests =
-    suite "Word Count"
+    describe "Word Count"
         [ test "count one word"
-            (assertEqual [ ( "word", 1 ) ]
-                (wordCount "word" |> Dict.toList)
+            (\() ->
+                Expect.equal [ ( "word", 1 ) ]
+                    (wordCount "word" |> Dict.toList)
             )
         , test "count one of each word"
-            (assertEqual [ ( "each", 1 ), ( "of", 1 ), ( "one", 1 ) ]
-                (wordCount "one of each" |> Dict.toList)
+            (\() ->
+                Expect.equal [ ( "each", 1 ), ( "of", 1 ), ( "one", 1 ) ]
+                    (wordCount "one of each" |> Dict.toList)
             )
         , test "multiple occurrences of a word"
-            (assertEqual [ ( "blue", 1 ), ( "fish", 4 ), ( "one", 1 ), ( "red", 1 ), ( "two", 1 ) ]
-                (wordCount "one fish two fish red fish blue fish" |> Dict.toList)
+            (\() ->
+                Expect.equal [ ( "blue", 1 ), ( "fish", 4 ), ( "one", 1 ), ( "red", 1 ), ( "two", 1 ) ]
+                    (wordCount "one fish two fish red fish blue fish" |> Dict.toList)
             )
         , test "ignore punctuation"
-            (assertEqual [ ( "as", 1 ), ( "car", 1 ), ( "carpet", 1 ), ( "java", 1 ), ( "javascript", 1 ) ]
-                (wordCount "car : carpet as java : javascript!!&@$%^&" |> Dict.toList)
+            (\() ->
+                Expect.equal [ ( "as", 1 ), ( "car", 1 ), ( "carpet", 1 ), ( "java", 1 ), ( "javascript", 1 ) ]
+                    (wordCount "car : carpet as java : javascript!!&@$%^&" |> Dict.toList)
             )
         , test "include numbers"
-            (assertEqual [ ( "1", 1 ), ( "2", 1 ), ( "testing", 2 ) ]
-                (wordCount "testing, 1, 2 testing" |> Dict.toList)
+            (\() ->
+                Expect.equal [ ( "1", 1 ), ( "2", 1 ), ( "testing", 2 ) ]
+                    (wordCount "testing, 1, 2 testing" |> Dict.toList)
             )
         , test "normalize case"
-            (assertEqual [ ( "go", 3 ), ( "stop", 2 ) ]
-                (wordCount "go Go GO Stop stop" |> Dict.toList)
+            (\() ->
+                Expect.equal [ ( "go", 3 ), ( "stop", 2 ) ]
+                    (wordCount "go Go GO Stop stop" |> Dict.toList)
             )
         ]
 
 
 main : Program Never
 main =
-    runSuite tests
+    run emit tests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/exercises/word-count/WordCountTests.elm
+++ b/exercises/word-count/WordCountTests.elm
@@ -11,36 +11,30 @@ import WordCount exposing (wordCount)
 tests : Test
 tests =
     describe "Word Count"
-        [ test "count one word"
-            (\() ->
+        [ test "count one word" <|
+            \() ->
                 Expect.equal [ ( "word", 1 ) ]
                     (wordCount "word" |> Dict.toList)
-            )
-        , test "count one of each word"
-            (\() ->
+        , test "count one of each word" <|
+            \() ->
                 Expect.equal [ ( "each", 1 ), ( "of", 1 ), ( "one", 1 ) ]
                     (wordCount "one of each" |> Dict.toList)
-            )
-        , test "multiple occurrences of a word"
-            (\() ->
+        , test "multiple occurrences of a word" <|
+            \() ->
                 Expect.equal [ ( "blue", 1 ), ( "fish", 4 ), ( "one", 1 ), ( "red", 1 ), ( "two", 1 ) ]
                     (wordCount "one fish two fish red fish blue fish" |> Dict.toList)
-            )
-        , test "ignore punctuation"
-            (\() ->
+        , test "ignore punctuation" <|
+            \() ->
                 Expect.equal [ ( "as", 1 ), ( "car", 1 ), ( "carpet", 1 ), ( "java", 1 ), ( "javascript", 1 ) ]
                     (wordCount "car : carpet as java : javascript!!&@$%^&" |> Dict.toList)
-            )
-        , test "include numbers"
-            (\() ->
+        , test "include numbers" <|
+            \() ->
                 Expect.equal [ ( "1", 1 ), ( "2", 1 ), ( "testing", 2 ) ]
                     (wordCount "testing, 1, 2 testing" |> Dict.toList)
-            )
-        , test "normalize case"
-            (\() ->
+        , test "normalize case" <|
+            \() ->
                 Expect.equal [ ( "go", 3 ), ( "stop", 2 ) ]
                     (wordCount "go Go GO Stop stop" |> Dict.toList)
-            )
         ]
 
 

--- a/exercises/word-count/elm-package.json
+++ b/exercises/word-count/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
     "repository": "https://github.com/exercism/xelm.git",
     "license": "BSD3",
@@ -8,8 +8,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/exercises/word-count/runtests.bat
+++ b/exercises/word-count/runtests.bat
@@ -1,4 +1,0 @@
-@echo off
-for %%f in (*Tests.elm) do (
-  elm-make %%f --yes --output build.js && node build.js
-)

--- a/exercises/word-count/runtests.sh
+++ b/exercises/word-count/runtests.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-elm-make *Tests.elm --yes --output build.js && node build.js


### PR DESCRIPTION
This is an example of what an exercise upgraded to elm-test 2.0 looks like (fixes #95). Among other highlights, I've reenabled the node elm-test runner workflow (`npm install -g elm-test`) as before, so the output is much nicer and by ditching the runtests scripts we can close #76.

- [x] Update the rest of the exercises
- [x] Update the installation/running docs
- [x] Get a 👍  from at least one other human being