### PR TITLE
Use a type to express triagles instead of strings

### DIFF
--- a/exercises/triangle/Triangle.elm
+++ b/exercises/triangle/Triangle.elm
@@ -1,1 +1,6 @@
 module Triangle exposing (..)
+
+
+version : Int
+version =
+    2

--- a/exercises/triangle/Triangle.example
+++ b/exercises/triangle/Triangle.example
@@ -9,6 +9,11 @@ type Triangle
     | Scalene
 
 
+version : Int
+version =
+    2
+
+
 triangleKind : number -> number -> number -> Result String Triangle
 triangleKind x y z =
     if x <= 0 || y <= 0 || z <= 0 then

--- a/exercises/triangle/Triangle.example
+++ b/exercises/triangle/Triangle.example
@@ -3,7 +3,13 @@ module Triangle exposing (..)
 import Set
 
 
-triangleKind : number -> number -> number -> Result String String
+type Triangle
+    = Equilateral
+    | Isosceles
+    | Scalene
+
+
+triangleKind : number -> number -> number -> Result String Triangle
 triangleKind x y z =
     if x <= 0 || y <= 0 || z <= 0 then
         Err "Invalid lengths"
@@ -12,10 +18,10 @@ triangleKind x y z =
     else
         case Set.size (Set.fromList [ x, y, z ]) of
             1 ->
-                Ok "equilateral"
+                Ok Equilateral
 
             2 ->
-                Ok "isosceles"
+                Ok Isosceles
 
             _ ->
-                Ok "scalene"
+                Ok Scalene

--- a/exercises/triangle/TriangleTests.elm
+++ b/exercises/triangle/TriangleTests.elm
@@ -1,32 +1,32 @@
 module Main exposing (..)
 
 import ElmTest exposing (..)
-import Triangle exposing (triangleKind)
+import Triangle exposing (..)
 
 
 tests : Test
 tests =
     suite "triangleKind"
         [ test "equilateral triangles have equal sides"
-            (assertEqual (Ok "equilateral") (triangleKind 2 2 2))
+            (assertEqual (Ok Equilateral) (triangleKind 2 2 2))
         , test "larger equilateral triangles also have equal sides"
-            (assertEqual (Ok "equilateral") (triangleKind 10 10 10))
+            (assertEqual (Ok Equilateral) (triangleKind 10 10 10))
         , test "isosceles triangles have last two sides equal"
-            (assertEqual (Ok "isosceles") (triangleKind 3 4 4))
+            (assertEqual (Ok Isosceles) (triangleKind 3 4 4))
         , test "isosceles triangles have first and last sides equal"
-            (assertEqual (Ok "isosceles") (triangleKind 4 3 4))
+            (assertEqual (Ok Isosceles) (triangleKind 4 3 4))
         , test "isosceles triangles have two first sides equal"
-            (assertEqual (Ok "isosceles") (triangleKind 4 4 3))
+            (assertEqual (Ok Isosceles) (triangleKind 4 4 3))
         , test "isosceles triangles have in fact exactly two sides equal"
-            (assertEqual (Ok "isosceles") (triangleKind 10 10 2))
+            (assertEqual (Ok Isosceles) (triangleKind 10 10 2))
         , test "scalene triangles have no equal sides"
-            (assertEqual (Ok "scalene") (triangleKind 3 4 5))
+            (assertEqual (Ok Scalene) (triangleKind 3 4 5))
         , test "scalene triangles have no equal sides at a larger scale too"
-            (assertEqual (Ok "scalene") (triangleKind 10 11 12))
+            (assertEqual (Ok Scalene) (triangleKind 10 11 12))
         , test "scalene triangles have no equal sides at a larger scale too 2"
-            (assertEqual (Ok "scalene") (triangleKind 5 4 2))
+            (assertEqual (Ok Scalene) (triangleKind 5 4 2))
         , test "very small triangles are legal"
-            (assertEqual (Ok "scalene") (triangleKind 0.4 0.6 0.3))
+            (assertEqual (Ok Scalene) (triangleKind 0.4 0.6 0.3))
         , test "triangles with no size are illegal"
             (assertEqual (Err "Invalid lengths") (triangleKind 0 0 0))
         , test "triangles with negative sides are illegal"

--- a/exercises/triangle/TriangleTests.elm
+++ b/exercises/triangle/TriangleTests.elm
@@ -7,7 +7,9 @@ import Triangle exposing (..)
 tests : Test
 tests =
     suite "triangleKind"
-        [ test "equilateral triangles have equal sides"
+        [ test "the solution is for the correct version of the test"
+            (assertEqual 2 version)
+        , test "equilateral triangles have equal sides"
             (assertEqual (Ok Equilateral) (triangleKind 2 2 2))
         , test "larger equilateral triangles also have equal sides"
             (assertEqual (Ok Equilateral) (triangleKind 10 10 10))


### PR DESCRIPTION
Hello!

For enum values such as this one found in the Triangle exercise I think we should avoid recommending use of strings in place of real types.