### PR TITLE
Add version in stub solution files

### DIFF
--- a/exercises/run-length-encoding/RunLengthEncoding.elm
+++ b/exercises/run-length-encoding/RunLengthEncoding.elm
@@ -1,1 +1,6 @@
 module RunLengthEncoding exposing (..)
+
+
+version : Int
+version =
+  2  

--- a/exercises/sublist/Sublist.elm
+++ b/exercises/sublist/Sublist.elm
@@ -1,1 +1,6 @@
 module Sublist exposing (..)
+
+
+version : Int
+version =
+  2


### PR DESCRIPTION
The [run-length-encoding](https://github.com/exercism/xelm/blob/312ab266a01a3db5cfe1170be45f464fdb36389f/exercises/run-length-encoding/RunLengthEncodingTests.elm) and [sublist](https://github.com/exercism/xelm/blob/312ab266a01a3db5cfe1170be45f464fdb36389f/exercises/sublist/SublistTests.elm) exercises both test for a specific version of the implementation.  The [nucleotide-count test](https://github.com/exercism/xelm/blob/312ab266a01a3db5cfe1170be45f464fdb36389f/exercises/nucleotide-count/NucleotideCountTests.elm) also tests for this version, but makes it easier for the user by including the version in the [default implementation](https://github.com/exercism/xelm/blob/312ab266a01a3db5cfe1170be45f464fdb36389f/exercises/nucleotide-count/NucleotideCount.elm). 

This PR adds an implementation of the version in the default implementation files.

By the way, the `triangle` exercise has it the other way around: [Triangle.elm](https://github.com/exercism/xelm/blob/312ab266a01a3db5cfe1170be45f464fdb36389f/exercises/triangle/Triangle.elm) contains a default version but [TriangleTests](https://github.com/exercism/xelm/blob/312ab266a01a3db5cfe1170be45f464fdb36389f/exercises/triangle/TriangleTests.elm) does not test for the version. I'm not sure what to do with this?
