### PR TITLE
fixed a bug in the Bob tests

### DIFF
--- a/exercises/bob/BobTests.elm
+++ b/exercises/bob/BobTests.elm
@@ -76,7 +76,7 @@ tests =
             \() ->
                 Expect.equal
                     "Whoa, chill out!"
-                    (Bob.hey "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!)")
+                    (Bob.hey "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!")
         , test "shouting with no exclamation mark" <|
             \() ->
                 Expect.equal


### PR DESCRIPTION
Took out one parenthesis. The Elm Bob tests didn't match the Elm tests in Ruby or JavaScript; with this PR, now they do.

Elm tests: `"ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!)"`

[JS tests](https://github.com/exercism/xjavascript/blob/master/exercises/bob/bob.spec.js#L52): `"ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"`

[Ruby tests](https://github.com/exercism/xruby/blob/master/exercises/bob/bob_test.rb#L88): `"ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"`

(The parenthesis at the end of the string, in the Elm tests, isn't there in the tests from the other langauges.)

I first did the Bob exercise in the JavaScript track, then did it again in the Elm track. After I got the Elm version to work, I remembered that my code had been better in the JS version. I redid the Elm version using the JS regexes, and it failed.

Same regex failed in JS and worked in Elm. Wracked my brains for at least an hour, discovered a typo.

https://twitter.com/gilesgoatboy/status/796093012262744064