### PR TITLE
Improve pangram test

### DIFF
--- a/exercises/pangram/Tests.elm
+++ b/exercises/pangram/Tests.elm
@@ -22,6 +22,10 @@ tests =
             \() ->
                 Expect.equal False
                     (isPangram "a quick movement of the enemy will jeopardize five gunboats")
+        , test "missing character 'z'" <|
+            \() ->
+                Expect.equal False
+                    (isPangram "a quick movement of the enemy will jeopardixe five gunboats")
         , test "another missing character 'x'" <|
             \() ->
                 Expect.equal False


### PR DESCRIPTION
* Add sentence missing 'z'

My first submit was incorrect but pass all the test : [my first solution](http://exercism.io/submissions/4cd7170d66a540bcbd61894081bccbd0)
I propose to add a test where a 'z' is missing. I try to find (google) an English sentence where a 'z' is missing but I didn't succeed.

Could you improve my proposal with an English sentence  