### PR TITLE
Fix help page link and typo

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,11 +1,12 @@
 ## Elm Installation
 
-Refer to the [exercism help page][http://exercism.io/languages/elm] for Elm installation and learning
-resources.
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
 
 ## Writing the Code
 
-The first time you start an exercise, you'll need to ensure you have the appropriate dependancies installed.
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
 
 ```bash
 $ npm install


### PR DESCRIPTION
- [x] Use the correct markdown syntax for links.
- [x] Fix typo in the word "dependencies".
- [x] Wrap lines at 80 chars (seems to be the pattern used).