### PR TITLE
Tell elm where to find Triangle types

### DIFF
--- a/exercises/triangle/Tests.elm
+++ b/exercises/triangle/Tests.elm
@@ -11,25 +11,25 @@ tests : Test
 tests =
     describe "triangleKind"
         [ test "equilateral triangles have equal sides" <|
-            \() -> Expect.equal (Ok Equilateral) (triangleKind 2 2 2)
+            \() -> Expect.equal (Ok Triangle.Equilateral) (triangleKind 2 2 2)
         , test "larger equilateral triangles also have equal sides" <|
-            \() -> Expect.equal (Ok Equilateral) (triangleKind 10 10 10)
+            \() -> Expect.equal (Ok Triangle.Equilateral) (triangleKind 10 10 10)
         , test "isosceles triangles have last two sides equal" <|
-            \() -> Expect.equal (Ok Isosceles) (triangleKind 3 4 4)
+            \() -> Expect.equal (Ok Triangle.Isosceles) (triangleKind 3 4 4)
         , test "isosceles triangles have first and last sides equal" <|
-            \() -> Expect.equal (Ok Isosceles) (triangleKind 4 3 4)
+            \() -> Expect.equal (Ok Triangle.Isosceles) (triangleKind 4 3 4)
         , test "isosceles triangles have two first sides equal" <|
-            \() -> Expect.equal (Ok Isosceles) (triangleKind 4 4 3)
+            \() -> Expect.equal (Ok Triangle.Isosceles) (triangleKind 4 4 3)
         , test "isosceles triangles have in fact exactly two sides equal" <|
-            \() -> Expect.equal (Ok Isosceles) (triangleKind 10 10 2)
+            \() -> Expect.equal (Ok Triangle.Isosceles) (triangleKind 10 10 2)
         , test "scalene triangles have no equal sides" <|
-            \() -> Expect.equal (Ok Scalene) (triangleKind 3 4 5)
+            \() -> Expect.equal (Ok Triangle.Scalene) (triangleKind 3 4 5)
         , test "scalene triangles have no equal sides at a larger scale too" <|
-            \() -> Expect.equal (Ok Scalene) (triangleKind 10 11 12)
+            \() -> Expect.equal (Ok Triangle.Scalene) (triangleKind 10 11 12)
         , test "scalene triangles have no equal sides at a larger scale too 2" <|
-            \() -> Expect.equal (Ok Scalene) (triangleKind 5 4 2)
+            \() -> Expect.equal (Ok Triangle.Scalene) (triangleKind 5 4 2)
         , test "very small triangles are legal" <|
-            \() -> Expect.equal (Ok Scalene) (triangleKind 0.4 0.6 0.3)
+            \() -> Expect.equal (Ok Triangle.Scalene) (triangleKind 0.4 0.6 0.3)
         , test "triangles with no size are illegal" <|
             \() -> Expect.equal (Err "Invalid lengths") (triangleKind 0 0 0)
         , test "triangles with negative sides are illegal" <|


### PR DESCRIPTION
Without this I would get error like this
```
-- NAMING ERROR ------------------------------------------------------ Tests.elm

Cannot find variable `Equilateral`

14|             \() -> Expect.equal (Ok Equilateral) (triangleKind 2 2 2)
                                        ^^^^^^^^^^^
Maybe you want one of the following?

    Triangle.Equilateral

``