### PR TITLE
Pin all npm dependancies to specific versions

### DIFF
--- a/exercises/accumulate/package.json
+++ b/exercises/accumulate/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/allergies/package.json
+++ b/exercises/allergies/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/anagram/package.json
+++ b/exercises/anagram/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/atbash-cipher/package.json
+++ b/exercises/atbash-cipher/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/bob/package.json
+++ b/exercises/bob/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/gigasecond/package.json
+++ b/exercises/gigasecond/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/grade-school/package.json
+++ b/exercises/grade-school/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/hamming/package.json
+++ b/exercises/hamming/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/hello-world/package.json
+++ b/exercises/hello-world/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/largest-series-product/package.json
+++ b/exercises/largest-series-product/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/list-ops/package.json
+++ b/exercises/list-ops/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/nucleotide-count/package.json
+++ b/exercises/nucleotide-count/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/pangram/package.json
+++ b/exercises/pangram/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/phone-number/package.json
+++ b/exercises/phone-number/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/raindrops/package.json
+++ b/exercises/raindrops/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/rna-transcription/package.json
+++ b/exercises/rna-transcription/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/robot-simulator/package.json
+++ b/exercises/robot-simulator/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/roman-numerals/package.json
+++ b/exercises/roman-numerals/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/run-length-encoding/package.json
+++ b/exercises/run-length-encoding/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/say/package.json
+++ b/exercises/say/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/scrabble-score/package.json
+++ b/exercises/scrabble-score/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/series/package.json
+++ b/exercises/series/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/space-age/package.json
+++ b/exercises/space-age/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/strain/package.json
+++ b/exercises/strain/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/sublist/package.json
+++ b/exercises/sublist/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/sum-of-multiples/package.json
+++ b/exercises/sum-of-multiples/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/triangle/package.json
+++ b/exercises/triangle/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/exercises/word-count/package.json
+++ b/exercises/word-count/package.json
@@ -7,7 +7,7 @@
         "test": "elm-test"
     },
     "dependencies": {
-        "elm": "^0.18.0",
-        "elm-test": "^0.18.0"
+        "elm": "0.18.0",
+        "elm-test": "0.18.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test": "elm-test"
   },
   "dependencies": {
-    "elm": "^0.18.0",
-    "elm-test": "^0.18.0"
+    "elm": "0.18.0",
+    "elm-test": "0.18.3"
   }
 }


### PR DESCRIPTION
Needs #139 to be merged first. Should stop things like #138 from happening again.