### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -225,15 +225,6 @@
   "deprecated": [
 
   ],
-  "ignored": [
-    "bin",
-    "elm-stuff",
-    "node_modules",
-    "docs",
-    "tests",
-    "libsysconfcpus",
-    "sysconfcpus"
-  ],
   "foregone": [
 
   ]


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.